### PR TITLE
ODP-1862 Fix missing ozone-filesystem-hadoop3 in ranger ews libs

### DIFF
--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -185,7 +185,7 @@
           <include>org.apache.ozone:hdds-config:jar:${ozone.version}</include>
           <include>org.apache.ozone:hdds-interface-client:jar:${ozone.version}</include>
           <include>org.apache.ozone:ozone-interface-client:jar:${ozone.version}</include>
-          <include>org.apache.ozone:ozone-filesystem-hadoop3:${ozone.version}</include>
+          <include>org.apache.ozone:ozone-filesystem-hadoop3:jar:${ozone.version}</include>
           <include>org.apache.ratis:ratis-common:jar:${ratis.version}</include>
           <include>org.apache.ratis:ratis-proto:jar:${ratis.version}</include>
           <include>org.apache.ratis:ratis-thirdparty-misc:jar:${ratis.thirdparty.version}</include>

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -116,6 +116,11 @@ limitations under the License.
 	        <version>${ozone.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.ozone</groupId>
+            <artifactId>ozone-filesystem-hadoop3</artifactId>
+            <version>${ozone.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.databind.version}</version>


### PR DESCRIPTION
ODP-1862 Fix missing ozone-filesystem-hadoop3 in ranger ews libs for ozone plugin

The patch was tested locally.