### PR TITLE
ODP-1909 Updating ODP stack and CVE versions to JDK11 stack target versions 

### DIFF
--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -80,7 +80,7 @@
                     <include>com.google.code.findbugs:jsr305</include>
                     <include>io.netty:netty-all</include>
                     <include>com.thoughtworks.paranamer:paranamer</include>
-                    <include>org.xerial.snappy:snappy-java</include>
+                    <include>org.xerial.snappy:snappy-java:1.1.10.4</include>
                     <include>xmlenc:xmlenc</include>
                     <include>org.tukaani:xz</include>
                     <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -24,7 +24,7 @@
     <url>http://ranger.apache.org/</url>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.ranger</groupId>
-    <version>2.4.0</version>
+    <version>2.4.0.3.3.6.0-1</version>
     <artifactId>ranger</artifactId>
     <packaging>pom</packaging>
     <licenses>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hbase.jetty.version>9.3.27.v20190418</hbase.jetty.version>
+        <hbase.jetty.version>9.4.43.v20210629</hbase.jetty.version>
         <hadoop.version>3.1.1</hadoop.version>
     </properties>
     <parent>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hbase.jetty.version>9.4.43.v20210629</hbase.jetty.version>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.3.6.3.3.6.0-1</hadoop.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -164,7 +164,7 @@
         <dependency>
             <groupId>org.apache.tez</groupId>
             <artifactId>tez-dag</artifactId>
-            <version>0.10.1</version>
+            <version>0.10.3.3.3.6.0-1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.3.6.3.3.6.0-1</hadoop.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/knox-agent/pom.xml
+++ b/knox-agent/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <knox.jetty.version>9.4.31.v20200723</knox.jetty.version>
+        <knox.jetty.version>9.4.43.v20210629</knox.jetty.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -49,8 +49,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
             <version>${kafka.version}</version>
+            <scope>test</scope>
            <exclusions>
                 <exclusion>
                    <groupId>io.netty</groupId>

--- a/plugin-kafka/src/main/java/org/apache/ranger/authorization/kafka/authorizer/RangerKafkaAuthorizer.java
+++ b/plugin-kafka/src/main/java/org/apache/ranger/authorization/kafka/authorizer/RangerKafkaAuthorizer.java
@@ -19,21 +19,38 @@
 
 package org.apache.ranger.authorization.kafka.authorizer;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.kafka.common.Endpoint;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclBindingFilter;
+import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.JaasContext;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import scala.collection.immutable.HashSet;
-import scala.collection.immutable.Set;
-import kafka.security.auth.*;
-import kafka.network.RequestChannel.Session;
-
-import org.apache.commons.lang.StringUtils;
-import org.apache.kafka.common.security.auth.KafkaPrincipal;
+import org.apache.kafka.server.authorizer.AclCreateResult;
+import org.apache.kafka.server.authorizer.AclDeleteResult;
+import org.apache.kafka.server.authorizer.Action;
+import org.apache.kafka.server.authorizer.AuthorizableRequestContext;
+import org.apache.kafka.server.authorizer.AuthorizationResult;
+import org.apache.kafka.server.authorizer.Authorizer;
+import org.apache.kafka.server.authorizer.AuthorizerServerInfo;
 import org.apache.ranger.audit.provider.MiscUtil;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
 import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
 import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
 import org.apache.ranger.plugin.policyengine.RangerAccessResult;
@@ -43,286 +60,277 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RangerKafkaAuthorizer implements Authorizer {
-	private static final Logger logger = LoggerFactory
-			.getLogger(RangerKafkaAuthorizer.class);
-	private static final Logger PERF_KAFKAAUTH_REQUEST_LOG = RangerPerfTracer.getPerfLogger("kafkaauth.request");
+  private static final Logger logger = LoggerFactory.getLogger(RangerKafkaAuthorizer.class);
+  private static final Logger PERF_KAFKAAUTH_REQUEST_LOG = RangerPerfTracer.getPerfLogger("kafkaauth.request");
 
-	public static final String KEY_TOPIC = "topic";
-	public static final String KEY_CLUSTER = "cluster";
-	public static final String KEY_CONSUMER_GROUP = "consumergroup";
-	public static final String KEY_TRANSACTIONALID = "transactionalid";
-	public static final String KEY_DELEGATIONTOKEN = "delegationtoken";
+  public static final String ACCESS_TYPE_ALTER_CONFIGS = "alter_configs";
+  public static final String KEY_TOPIC = "topic";
+  public static final String KEY_CLUSTER = "cluster";
+  public static final String KEY_CONSUMER_GROUP = "consumergroup";
+  public static final String KEY_TRANSACTIONALID = "transactionalid";
+  public static final String KEY_DELEGATIONTOKEN = "delegationtoken";
+  public static final String ACCESS_TYPE_READ = "consume";
+  public static final String ACCESS_TYPE_WRITE = "publish";
+  public static final String ACCESS_TYPE_CREATE = "create";
+  public static final String ACCESS_TYPE_DELETE = "delete";
+  public static final String ACCESS_TYPE_CONFIGURE = "configure";
+  public static final String ACCESS_TYPE_DESCRIBE = "describe";
+  public static final String ACCESS_TYPE_DESCRIBE_CONFIGS = "describe_configs";
+  public static final String ACCESS_TYPE_CLUSTER_ACTION = "cluster_action";
+  public static final String ACCESS_TYPE_IDEMPOTENT_WRITE = "idempotent_write";
 
-	public static final String ACCESS_TYPE_READ = "consume";
-	public static final String ACCESS_TYPE_WRITE = "publish";
-	public static final String ACCESS_TYPE_CREATE = "create";
-	public static final String ACCESS_TYPE_DELETE = "delete";
-	public static final String ACCESS_TYPE_CONFIGURE = "configure";
-	public static final String ACCESS_TYPE_DESCRIBE = "describe";
-	public static final String ACCESS_TYPE_DESCRIBE_CONFIGS = "describe_configs";
-	public static final String ACCESS_TYPE_ALTER_CONFIGS    = "alter_configs";
-	public static final String ACCESS_TYPE_IDEMPOTENT_WRITE = "idempotent_write";
-	public static final String ACCESS_TYPE_CLUSTER_ACTION   = "cluster_action";
+  private static volatile RangerBasePlugin rangerPlugin = null;
+  RangerKafkaAuditHandler auditHandler = null;
 
-	private static volatile RangerBasePlugin rangerPlugin = null;
-	RangerKafkaAuditHandler auditHandler = null;
+  public RangerKafkaAuthorizer() {
+  }
 
-	public RangerKafkaAuthorizer() {
-	}
+  private static String mapToRangerAccessType(AclOperation operation) {
+    switch (operation) {
+      case READ:
+        return ACCESS_TYPE_READ;
+      case WRITE:
+        return ACCESS_TYPE_WRITE;
+      case ALTER:
+        return ACCESS_TYPE_CONFIGURE;
+      case DESCRIBE:
+        return ACCESS_TYPE_DESCRIBE;
+      case CLUSTER_ACTION:
+        return ACCESS_TYPE_CLUSTER_ACTION;
+      case CREATE:
+        return ACCESS_TYPE_CREATE;
+      case DELETE:
+        return ACCESS_TYPE_DELETE;
+      case DESCRIBE_CONFIGS:
+        return ACCESS_TYPE_DESCRIBE_CONFIGS;
+      case ALTER_CONFIGS:
+        return ACCESS_TYPE_ALTER_CONFIGS;
+      case IDEMPOTENT_WRITE:
+        return ACCESS_TYPE_IDEMPOTENT_WRITE;
+      case UNKNOWN:
+      case ANY:
+      case ALL:
+      default:
+        return null;
+    }
+  }
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see kafka.security.auth.Authorizer#configure(Map<String, Object>)
-	 */
-	@Override
-	public void configure(Map<String, ?> configs) {
-		RangerBasePlugin me = rangerPlugin;
-		if (me == null) {
-			synchronized(RangerKafkaAuthorizer.class) {
-				me = rangerPlugin;
-				if (me == null) {
-					try {
-						// Possible to override JAAS configuration which is used by Ranger, otherwise
-						// SASL_PLAINTEXT is used, which force Kafka to use 'sasl_plaintext.KafkaServer',
-						// if it's not defined, then it reverts to 'KafkaServer' configuration.
-						final Object jaasContext = configs.get("ranger.jaas.context");
-						final String listenerName = (jaasContext instanceof String
-								&& StringUtils.isNotEmpty((String) jaasContext)) ? (String) jaasContext
-										: SecurityProtocol.SASL_PLAINTEXT.name();
-						final String saslMechanism = SaslConfigs.GSSAPI_MECHANISM;
-						JaasContext context = JaasContext.loadServerContext(new ListenerName(listenerName), saslMechanism, configs);
-						MiscUtil.setUGIFromJAASConfig(context.name());
-						logger.info("LoginUser=" + MiscUtil.getUGILoginUser());
-					} catch (Throwable t) {
-						logger.error("Error getting principal.", t);
-					}
-					me = rangerPlugin = new RangerBasePlugin("kafka", "kafka");
-				}
-			}
-		}
-		logger.info("Calling plugin.init()");
-		rangerPlugin.init();
-		auditHandler = new RangerKafkaAuditHandler();
-		rangerPlugin.setResultProcessor(auditHandler);
-	}
+  private static String mapToResourceType(ResourceType resourceType) {
+    switch (resourceType) {
+      case TOPIC:
+        return KEY_TOPIC;
+      case CLUSTER:
+        return KEY_CLUSTER;
+      case GROUP:
+        return KEY_CONSUMER_GROUP;
+      case TRANSACTIONAL_ID:
+        return KEY_TRANSACTIONALID;
+      case DELEGATION_TOKEN:
+        return KEY_DELEGATIONTOKEN;
+      case ANY:
+      case UNKNOWN:
+      default:
+        return null;
+    }
+  }
 
-	@Override
-	public void close() {
-		logger.info("close() called on authorizer.");
-		try {
-			if (rangerPlugin != null) {
-				rangerPlugin.cleanup();
-			}
-		} catch (Throwable t) {
-			logger.error("Error closing RangerPlugin.", t);
-		}
-	}
+  private static RangerAccessResourceImpl createRangerAccessResource(String resourceTypeKey, String resourceName) {
+    RangerAccessResourceImpl rangerResource = new RangerAccessResourceImpl();
+    rangerResource.setValue(resourceTypeKey, resourceName);
+    return rangerResource;
+  }
 
-	@Override
-	public boolean authorize(Session session, Operation operation,
-			Resource resource) {
+  private static RangerAccessRequestImpl createRangerAccessRequest(String userName,
+                                                                   Set<String> userGroups,
+                                                                   String ip,
+                                                                   Date eventTime,
+                                                                   String resourceTypeKey,
+                                                                   String resourceName,
+                                                                   String accessType) {
+    RangerAccessRequestImpl rangerRequest = new RangerAccessRequestImpl();
+    rangerRequest.setResource(createRangerAccessResource(resourceTypeKey, resourceName));
+    rangerRequest.setUser(userName);
+    rangerRequest.setUserGroups(userGroups);
+    rangerRequest.setClientIPAddress(ip);
+    rangerRequest.setAccessTime(eventTime);
+    rangerRequest.setAccessType(accessType);
+    rangerRequest.setAction(accessType);
+    rangerRequest.setRequestData(resourceName);
+    return rangerRequest;
+  }
 
-		if (rangerPlugin == null) {
-			MiscUtil.logErrorMessageByInterval(logger,
-					"Authorizer is still not initialized");
-			return false;
-		}
+  private static List<AuthorizationResult> denyAll(List<Action> actions) {
+    return actions.stream().map(a -> AuthorizationResult.DENIED).collect(Collectors.toList());
+  }
 
-		RangerPerfTracer perf = null;
+  private static List<AuthorizationResult> mapResults(List<Action> actions, Collection<RangerAccessResult> results) {
+    if (CollectionUtils.isEmpty(results)) {
+      logger.error("Ranger Plugin returned null or empty. Returning Denied for all");
+      return denyAll(actions);
+    }
+    return results.stream()
+        .map(r -> r != null && r.getIsAllowed() ? AuthorizationResult.ALLOWED : AuthorizationResult.DENIED)
+        .collect(Collectors.toList());
+  }
 
-		if(RangerPerfTracer.isPerfTraceEnabled(PERF_KAFKAAUTH_REQUEST_LOG)) {
-			perf = RangerPerfTracer.getPerfTracer(PERF_KAFKAAUTH_REQUEST_LOG, "RangerKafkaAuthorizer.authorize(resource=" + resource + ")");
-		}
-		String userName = null;
-		if (session.principal() != null) {
-			userName = session.principal().getName();
-		}
-		java.util.Set<String> userGroups = MiscUtil
-				.getGroupsForRequestUser(userName);
-		String ip = session.clientAddress().getHostAddress();
+  private static String toString(AuthorizableRequestContext requestContext) {
+    return requestContext == null ? null :
+        String.format("AuthorizableRequestContext{principal=%s, clientAddress=%s, clientId=%s}",
+            requestContext.principal(), requestContext.clientAddress(), requestContext.clientId());
+  }
 
-		// skip leading slash
-		if (StringUtils.isNotEmpty(ip) && ip.charAt(0) == '/') {
-			ip = ip.substring(1);
-		}
+  @Override
+  public void close() {
+    logger.info("close() called on authorizer.");
+    try {
+      if (rangerPlugin != null) {
+        rangerPlugin.cleanup();
+      }
+    } catch (Throwable t) {
+      logger.error("Error closing RangerPlugin.", t);
+    }
+  }
 
-		Date eventTime = new Date();
-		String accessType = mapToRangerAccessType(operation);
-		boolean validationFailed = false;
-		String validationStr = "";
+  @Override
+  public void configure(Map<String, ?> configs) {
+    RangerBasePlugin me = rangerPlugin;
+    if (me == null) {
+      synchronized (RangerKafkaAuthorizer.class) {
+        me = rangerPlugin;
+        if (me == null) {
+          try {
+            // Possible to override JAAS configuration which is used by Ranger, otherwise
+            // SASL_PLAINTEXT is used, which force Kafka to use 'sasl_plaintext.KafkaServer',
+            // if it's not defined, then it reverts to 'KafkaServer' configuration.
+            final Object jaasContext = configs.get("ranger.jaas.context");
+            final String listenerName = (jaasContext instanceof String
+                && StringUtils.isNotEmpty((String) jaasContext)) ? (String) jaasContext
+                : SecurityProtocol.SASL_PLAINTEXT.name();
+            final String saslMechanism = SaslConfigs.GSSAPI_MECHANISM;
+            JaasContext context = JaasContext.loadServerContext(new ListenerName(listenerName), saslMechanism, configs);
+            MiscUtil.setUGIFromJAASConfig(context.name());
+            UserGroupInformation loginUser = MiscUtil.getUGILoginUser();
+            logger.info("LoginUser={}", loginUser);
+          } catch (Throwable t) {
+            logger.error("Error getting principal.", t);
+          }
+          rangerPlugin = new RangerBasePlugin("kafka", "kafka");
+          logger.info("Calling plugin.init()");
+          rangerPlugin.init();
+          auditHandler = new RangerKafkaAuditHandler();
+          rangerPlugin.setResultProcessor(auditHandler);
+        }
+      }
+    }
+  }
 
-		if (accessType == null) {
-			if (MiscUtil.logErrorMessageByInterval(logger,
-					"Unsupported access type. operation=" + operation)) {
-				logger.error("Unsupported access type. session=" + session
-						+ ", operation=" + operation + ", resource=" + resource);
-			}
-			validationFailed = true;
-			validationStr += "Unsupported access type. operation=" + operation;
-		}
-		String action = accessType;
+  @Override
+  public Map<Endpoint, ? extends CompletionStage<Void>> start(AuthorizerServerInfo serverInfo) {
+    return serverInfo.endpoints().stream()
+        .collect(Collectors.toMap(endpoint -> endpoint, endpoint -> CompletableFuture.completedFuture(null), (a, b) -> b));
+  }
 
-		RangerAccessRequestImpl rangerRequest = new RangerAccessRequestImpl();
-		rangerRequest.setUser(userName);
-		rangerRequest.setUserGroups(userGroups);
-		rangerRequest.setClientIPAddress(ip);
-		rangerRequest.setAccessTime(eventTime);
+  @Override
+  public List<AuthorizationResult> authorize(AuthorizableRequestContext requestContext, List<Action> actions) {
+    if (rangerPlugin == null) {
+      MiscUtil.logErrorMessageByInterval(logger, "Authorizer is still not initialized");
+      return denyAll(actions);
+    }
 
-		RangerAccessResourceImpl rangerResource = new RangerAccessResourceImpl();
-		rangerRequest.setResource(rangerResource);
-		rangerRequest.setAccessType(accessType);
-		rangerRequest.setAction(action);
-		rangerRequest.setRequestData(resource.name());
+    RangerPerfTracer perf = null;
+    if (RangerPerfTracer.isPerfTraceEnabled(PERF_KAFKAAUTH_REQUEST_LOG)) {
+      perf = RangerPerfTracer.getPerfTracer(PERF_KAFKAAUTH_REQUEST_LOG, "RangerKafkaAuthorizer.authorize(actions=" + actions + ")");
+    }
+    try {
+      return wrappedAuthorization(requestContext, actions);
+    } finally {
+      RangerPerfTracer.log(perf);
+    }
+  }
 
-		if (resource.resourceType().equals(Topic$.MODULE$)) {
-			rangerResource.setValue(KEY_TOPIC, resource.name());
-		} else if (resource.resourceType().equals(Cluster$.MODULE$)) {
-			rangerResource.setValue(KEY_CLUSTER, resource.name());
-		} else if (resource.resourceType().equals(Group$.MODULE$)) {
-			rangerResource.setValue(KEY_CONSUMER_GROUP, resource.name());
-		} else if (resource.resourceType().equals(TransactionalId$.MODULE$)) {
-			rangerResource.setValue(KEY_TRANSACTIONALID, resource.name());
-		} else if (resource.resourceType().equals(DelegationToken$.MODULE$)) {
-			rangerResource.setValue(KEY_DELEGATIONTOKEN, resource.name());
-		} else {
-			logger.error("Unsupported resourceType=" + resource.resourceType());
-			validationFailed = true;
-		}
+  private List<AuthorizationResult> wrappedAuthorization(AuthorizableRequestContext requestContext, List<Action> actions) {
+    if (CollectionUtils.isEmpty(actions)) {
+      return Collections.emptyList();
+    }
+    String userName = requestContext.principal() == null ? null : requestContext.principal().getName();
+    Set<String> userGroups = MiscUtil.getGroupsForRequestUser(userName);
+    String hostAddress = requestContext.clientAddress() == null ? null : requestContext.clientAddress().getHostAddress();
+    String ip = StringUtils.isNotEmpty(hostAddress) && hostAddress.charAt(0) == '/' ? hostAddress.substring(1) : hostAddress;
+    Date eventTime = new Date();
 
-		boolean returnValue = false;
-		if (validationFailed) {
-			MiscUtil.logErrorMessageByInterval(logger, validationStr
-					+ ", request=" + rangerRequest);
-		} else {
+    List<RangerAccessRequest> rangerRequests = new ArrayList<>();
+    for (Action action : actions) {
+      String accessType = mapToRangerAccessType(action.operation());
+      if (accessType == null) {
+        MiscUtil.logErrorMessageByInterval(logger, "Unsupported access type, requestContext=" + toString(requestContext) +
+            ", actions=" + actions + ", operation=" + action.operation());
+        return denyAll(actions);
+      }
+      String resourceTypeKey = mapToResourceType(action.resourcePattern().resourceType());
+      if (resourceTypeKey == null) {
+        MiscUtil.logErrorMessageByInterval(logger, "Unsupported resource type, requestContext=" + toString(requestContext) +
+            ", actions=" + actions + ", resourceType=" + action.resourcePattern().resourceType());
+        return denyAll(actions);
+      }
 
-			try {
-				RangerAccessResult result = rangerPlugin
-						.isAccessAllowed(rangerRequest);
-				if (result == null) {
-					logger.error("Ranger Plugin returned null. Returning false");
-				} else {
-					returnValue = result.getIsAllowed();
-				}
-			} catch (Throwable t) {
-				logger.error("Error while calling isAccessAllowed(). request="
-						+ rangerRequest, t);
-			} finally {
-				auditHandler.flushAudit();
-			}
-		}
-		RangerPerfTracer.log(perf);
+      RangerAccessRequestImpl rangerAccessRequest = createRangerAccessRequest(
+          userName,
+          userGroups,
+          ip,
+          eventTime,
+          resourceTypeKey,
+          action.resourcePattern().name(),
+          accessType);
+      rangerRequests.add(rangerAccessRequest);
+    }
 
-		if (logger.isDebugEnabled()) {
-			logger.debug("rangerRequest=" + rangerRequest + ", return="
-					+ returnValue);
-		}
-		return returnValue;
-	}
+    Collection<RangerAccessResult> results = callRangerPlugin(rangerRequests);
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * kafka.security.auth.Authorizer#addAcls(scala.collection.immutable.Set,
-	 * kafka.security.auth.Resource)
-	 */
-	@Override
-	public void addAcls(Set<Acl> acls, Resource resource) {
-		logger.error("addAcls(Set<Acl>, Resource) is not supported by Ranger for Kafka");
-	}
+    List<AuthorizationResult> authorizationResults = mapResults(actions, results);
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * kafka.security.auth.Authorizer#removeAcls(scala.collection.immutable.Set,
-	 * kafka.security.auth.Resource)
-	 */
-	@Override
-	public boolean removeAcls(Set<Acl> acls, Resource resource) {
-		logger.error("removeAcls(Set<Acl>, Resource) is not supported by Ranger for Kafka");
-		return false;
-	}
+    logger.debug("rangerRequests={}, return={}", rangerRequests, authorizationResults);
+    return authorizationResults;
+  }
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * kafka.security.auth.Authorizer#removeAcls(kafka.security.auth.Resource)
-	 */
-	@Override
-	public boolean removeAcls(Resource resource) {
-		logger.error("removeAcls(Resource) is not supported by Ranger for Kafka");
-		return false;
-	}
+  private Collection<RangerAccessResult> callRangerPlugin(List<RangerAccessRequest> rangerRequests) {
+    try {
+      return rangerPlugin.isAccessAllowed(rangerRequests);
+    } catch (Throwable t) {
+      logger.error("Error while calling isAccessAllowed(). requests={}", rangerRequests, t);
+      return null;
+    } finally {
+      auditHandler.flushAudit();
+    }
+  }
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see kafka.security.auth.Authorizer#getAcls(kafka.security.auth.Resource)
-	 */
-	@Override
-	public Set<Acl> getAcls(Resource resource) {
-		Set<Acl> aclList = new HashSet<Acl>();
-		logger.error("getAcls(Resource) is not supported by Ranger for Kafka");
+  @Override
+  public List<? extends CompletionStage<AclCreateResult>> createAcls(AuthorizableRequestContext requestContext, List<AclBinding> aclBindings) {
+    logger.error("createAcls is not supported by Ranger for Kafka");
 
-		return aclList;
-	}
+    return aclBindings.stream()
+        .map(ab -> {
+          CompletableFuture<AclCreateResult> completableFuture = new CompletableFuture<>();
+          completableFuture.completeExceptionally(new UnsupportedOperationException("createAcls is not supported by Ranger for Kafka"));
+          return completableFuture;
+        })
+        .collect(Collectors.toList());
+  }
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see
-	 * kafka.security.auth.Authorizer#getAcls(kafka.security.auth.KafkaPrincipal
-	 * )
-	 */
-	@Override
-	public scala.collection.immutable.Map<Resource, Set<Acl>> getAcls(
-			KafkaPrincipal principal) {
-		scala.collection.immutable.Map<Resource, Set<Acl>> aclList = new scala.collection.immutable.HashMap<Resource, Set<Acl>>();
-		logger.error("getAcls(KafkaPrincipal) is not supported by Ranger for Kafka");
-		return aclList;
-	}
+  @Override
+  public List<? extends CompletionStage<AclDeleteResult>> deleteAcls(AuthorizableRequestContext requestContext, List<AclBindingFilter> aclBindingFilters) {
+    logger.error("deleteAcls is not supported by Ranger for Kafka");
+    return aclBindingFilters.stream()
+        .map(ab -> {
+          CompletableFuture<AclDeleteResult> completableFuture = new CompletableFuture<>();
+          completableFuture.completeExceptionally(new UnsupportedOperationException("deleteAcls is not supported by Ranger for Kafka"));
+          return completableFuture;
+        })
+        .collect(Collectors.toList());
+  }
 
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see kafka.security.auth.Authorizer#getAcls()
-	 */
-	@Override
-	public scala.collection.immutable.Map<Resource, Set<Acl>> getAcls() {
-		scala.collection.immutable.Map<Resource, Set<Acl>> aclList = new scala.collection.immutable.HashMap<Resource, Set<Acl>>();
-		logger.error("getAcls() is not supported by Ranger for Kafka");
-		return aclList;
-	}
-
-	/**
-	 * @param operation
-	 * @return
-	 */
-	private String mapToRangerAccessType(Operation operation) {
-		if (operation.equals(Read$.MODULE$)) {
-			return ACCESS_TYPE_READ;
-		} else if (operation.equals(Write$.MODULE$)) {
-			return ACCESS_TYPE_WRITE;
-		} else if (operation.equals(Alter$.MODULE$)) {
-			return ACCESS_TYPE_CONFIGURE;
-		} else if (operation.equals(Describe$.MODULE$)) {
-			return ACCESS_TYPE_DESCRIBE;
-		} else if (operation.equals(ClusterAction$.MODULE$)) {
-			return ACCESS_TYPE_CLUSTER_ACTION;
-		} else if (operation.equals(Create$.MODULE$)) {
-			return ACCESS_TYPE_CREATE;
-		} else if (operation.equals(Delete$.MODULE$)) {
-			return ACCESS_TYPE_DELETE;
-		} else if (operation.equals(DescribeConfigs$.MODULE$)) {
-			return ACCESS_TYPE_DESCRIBE_CONFIGS;
-		} else if (operation.equals(AlterConfigs$.MODULE$)) {
-			return ACCESS_TYPE_ALTER_CONFIGS;
-		} else if (operation.equals(IdempotentWrite$.MODULE$)) {
-			return ACCESS_TYPE_IDEMPOTENT_WRITE;
-		}
-		return null;
-	}
+  @Override
+  public Iterable<AclBinding> acls(AclBindingFilter filter) {
+    logger.error("(getting) acls is not supported by Ranger for Kafka");
+    throw new UnsupportedOperationException("(getting) acls is not supported by Ranger for Kafka");
+  }
 }

--- a/plugin-kudu/pom.xml
+++ b/plugin-kudu/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-kylin/pom.xml
+++ b/plugin-kylin/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-nestedstructure/pom.xml
+++ b/plugin-nestedstructure/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>ranger</artifactId>
         <groupId>org.apache.ranger</groupId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/plugin-presto/pom.xml
+++ b/plugin-presto/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -32,9 +32,9 @@
     </parent>
 
     <properties>
-        <hadoop.version>3.1.1</hadoop.version>
+        <hadoop.version>3.3.6.3.3.6.0-1</hadoop.version>
         <jersey.version>2.22.1</jersey.version>
-        <jettison.version>1.1</jettison.version>
+        <jettison.version>1.5.4</jettison.version>
         <servlet-api.version>3.0.1</servlet-api.version>
     </properties>
 

--- a/plugin-sqoop/pom.xml
+++ b/plugin-sqoop/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/plugin-trino/pom.xml
+++ b/plugin-trino/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <codehaus.woodstox.stax2api.version>4.2.1</codehaus.woodstox.stax2api.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version>
         <fasterxml.jackson.version>2.12.7</fasterxml.jackson.version>
-        <fasterxml.jackson.databind.version>2.12.7</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.databind.version>2.12.7.1</fasterxml.jackson.databind.version>
         <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
         <jna.version>5.7.0</jna.version>
         <jna-platform.version>5.2.0</jna-platform.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,11 +125,11 @@
         <hamcrest.version>2.2</hamcrest.version>
         <hbase.version>2.5.8.3.3.6.0-1</hbase.version>
         <hive.version>4.0.0.3.3.6.0-1</hive.version>
-        <hive.storage-api.version>2.7.2</hive.storage-api.version>
+        <hive.storage-api.version>4.0.0</hive.storage-api.version>
         <orc.version>1.5.8</orc.version>
-        <hbase-shaded-protobuf>3.5.1</hbase-shaded-protobuf>
-        <hbase-shaded-netty>4.1.94.Final</hbase-shaded-netty>
-        <hbase-shaded-miscellaneous>3.5.1</hbase-shaded-miscellaneous>
+        <hbase-shaded-protobuf>4.1.5</hbase-shaded-protobuf>
+        <hbase-shaded-netty>4.1.5</hbase-shaded-netty>
+        <hbase-shaded-miscellaneous>4.1.5</hbase-shaded-miscellaneous>
         <libfb303.version>0.9.3</libfb303.version>
         <libthrift.version>0.14.1</libthrift.version>
         <htrace-core.version>4.1.0-incubating</htrace-core.version>
@@ -158,9 +158,9 @@
         <jsonsmart.version>2.4.10</jsonsmart.version>
         <jsr250.version>1.0</jsr250.version>
         <jsr305.version>1.3.9</jsr305.version>
-        <schema.registry.version>1.0.0</schema.registry.version>
+        <schema.registry.version>1.0.1</schema.registry.version>
         <junit.version>4.13.1</junit.version>
-        <kafka.version>2.8.2</kafka.version>
+        <kafka.version>3.7.1</kafka.version>
         <kerby.version>2.0.3</kerby.version>
         <knox.gateway.version>2.0.0</knox.gateway.version>
         <kylin.version>3.1.3</kylin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf-java.version>3.19.3</protobuf-java.version>
         <gcp.protobuf-java.version>3.19.3</gcp.protobuf-java.version>
+        <ratis.version>3.0.1</ratis.version>
+        <ratis.thirdparty.version>1.0.5</ratis.thirdparty.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.xml.version>1.0.4</scala.xml.version>
@@ -208,10 +210,10 @@
         <codehaus.woodstox.stax2api.version>4.2.1</codehaus.woodstox.stax2api.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version>
         <fasterxml.jackson.version>2.12.7</fasterxml.jackson.version>
-        <fasterxml.jackson.databind.version>2.12.7.1</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.databind.version>2.12.7</fasterxml.jackson.databind.version>
         <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
         <jna.version>5.7.0</jna.version>
-        <jna-platform.version>5.7.0</jna-platform.version>
+        <jna-platform.version>5.2.0</jna-platform.version>
         <!-- presto plugin deps -->
         <presto.airlift.version>0.192</presto.airlift.version>
         <presto.bval-jsr.version>2.0.0</presto.bval-jsr.version>
@@ -293,8 +295,8 @@
                 <module>unixauthnative</module>
                 <module>ranger-util</module>
                 <module>plugin-kms</module>
-		<module>tagsync</module>
-		<module>plugin-elasticsearch</module>
+		            <module>tagsync</module>
+                <module>plugin-elasticsearch</module>
                 <module>ranger-hdfs-plugin-shim</module>
                 <module>ranger-plugin-classloader</module>
                 <module>ranger-hive-plugin-shim</module>
@@ -304,8 +306,8 @@
                 <module>ranger-ozone-plugin-shim</module>
                 <module>ranger-kafka-plugin-shim</module>
                 <module>ranger-solr-plugin-shim</module>
-		<module>ranger-kms-plugin-shim</module>
-		<module>ranger-elasticsearch-plugin-shim</module>
+		            <module>ranger-kms-plugin-shim</module>
+		            <module>ranger-elasticsearch-plugin-shim</module>
                 <module>ranger-examples</module>
                 <module>ranger-tools</module>
                 <!--

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <hbase-shaded-netty>4.1.5</hbase-shaded-netty>
         <hbase-shaded-miscellaneous>4.1.5</hbase-shaded-miscellaneous>
         <libfb303.version>0.9.3</libfb303.version>
-        <libthrift.version>0.14.1</libthrift.version>
+        <libthrift.version>0.16.0</libthrift.version>
         <htrace-core.version>4.1.0-incubating</htrace-core.version>
         <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.6</httpcomponents.httpcore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
         <aspectj.version>1.8.2</aspectj.version>
         <assembly.plugin.version>2.6</assembly.plugin.version>
         <atlas.version>2.2.0</atlas.version>
-        <atlas.jackson.version>2.11.3</atlas.jackson.version>
-        <atlas.jackson.databind.version>2.11.3</atlas.jackson.databind.version>
-        <atlas.jettison.version>1.3.7</atlas.jettison.version>
+        <atlas.jackson.version>2.12.7</atlas.jackson.version>
+        <atlas.jackson.databind.version>2.12.7.1</atlas.jackson.databind.version>
+        <atlas.jettison.version>1.5.4</atlas.jettison.version>
         <atlas.commons.logging.version>1.1.3</atlas.commons.logging.version>
         <bouncycastle.version>1.55</bouncycastle.version>
         <c3p0.version>0.9.5.5</c3p0.version>
@@ -115,7 +115,7 @@
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <enunciate.version>2.13.2</enunciate.version>
         <spotbugs.plugin.version>4.5.0.0</spotbugs.plugin.version>
-        <google.guava.version>27.0-jre</google.guava.version>
+        <google.guava.version>32.0.1-jre</google.guava.version>
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>
         <graalvm.version>22.3.0</graalvm.version>
         <gson.version>2.9.0</gson.version>
@@ -128,7 +128,7 @@
         <hive.storage-api.version>2.7.2</hive.storage-api.version>
         <orc.version>1.5.8</orc.version>
         <hbase-shaded-protobuf>3.5.1</hbase-shaded-protobuf>
-        <hbase-shaded-netty>3.5.1</hbase-shaded-netty>
+        <hbase-shaded-netty>4.1.94.Final</hbase-shaded-netty>
         <hbase-shaded-miscellaneous>3.5.1</hbase-shaded-miscellaneous>
         <libfb303.version>0.9.3</libfb303.version>
         <libthrift.version>0.14.1</libthrift.version>
@@ -143,14 +143,14 @@
         <javax.annotation-api>1.3.2</javax.annotation-api>
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <jericho.html.version>3.3</jericho.html.version>
-        <jersey-bundle.version>1.19.3</jersey-bundle.version>
+        <jersey-bundle.version>1.19.4</jersey-bundle.version>
         <jersey-client.version>2.35</jersey-client.version>
-        <jersey-core.version>1.19.3</jersey-core.version>
+        <jersey-core.version>1.19.4</jersey-core.version>
         <jersey-core-asl.version>1.9.13</jersey-core-asl.version>
-        <jersey-server.version>1.19.3</jersey-server.version>
-        <jersey-spring.version>1.19.3</jersey-spring.version>
+        <jersey-server.version>1.19.4</jersey-server.version>
+        <jersey-spring.version>1.19.4</jersey-spring.version>
         <jaxb-impl.version>2.3.3</jaxb-impl.version>
-        <jettison.version>1.1</jettison.version>
+        <jettison.version>1.5.4</jettison.version>
         <jetty-client.version>9.4.44.v20210927</jetty-client.version>
         <jline.version>0.9.94</jline.version>
         <jopt-simple.version>3.2</jopt-simple.version>
@@ -158,7 +158,7 @@
         <jsonsmart.version>2.4.10</jsonsmart.version>
         <jsr250.version>1.0</jsr250.version>
         <jsr305.version>1.3.9</jsr305.version>
-        <schema.registry.version>1.0.1</schema.registry.version>
+        <schema.registry.version>1.0.0</schema.registry.version>
         <junit.version>4.13.1</junit.version>
         <kafka.version>2.8.2</kafka.version>
         <kerby.version>2.0.3</kerby.version>
@@ -200,7 +200,7 @@
         <springframework.version>5.3.27</springframework.version>
         <sqoop.version>1.99.7</sqoop.version>
         <storm.version>1.2.4</storm.version>
-        <sun-jersey-bundle.version>1.19</sun-jersey-bundle.version>
+        <sun-jersey-bundle.version>1.19.4</sun-jersey-bundle.version>
         <tomcat.embed.version>8.5.86</tomcat.embed.version>
         <testng.version>6.9.4</testng.version>
         <velocity.version>2.3</velocity.version>
@@ -216,7 +216,7 @@
         <presto.airlift.version>0.192</presto.airlift.version>
         <presto.bval-jsr.version>2.0.0</presto.bval-jsr.version>
         <presto.guice.version>4.2.2</presto.guice.version>
-        <presto.guava.version>26.0-jre</presto.guava.version>
+        <presto.guava.version>32.0.1-jre</presto.guava.version>
         <presto.validation-api.version>2.0.1.Final</presto.validation-api.version>
         <presto.re2j.version>1.1</presto.re2j.version>
 
@@ -224,7 +224,7 @@
         <trino.airlift.version>0.192</trino.airlift.version>
         <trino.bval-jsr.version>2.0.0</trino.bval-jsr.version>
         <trino.guice.version>5.1.0</trino.guice.version>
-        <trino.guava.version>26.0-jre</trino.guava.version>
+        <trino.guava.version>32.0.1-jre</trino.guava.version>
         <trino.validation-api.version>2.0.1.Final</trino.validation-api.version>
         <trino.re2j.version>1.1</trino.re2j.version>
 

--- a/ranger-atlas-plugin-shim/pom.xml
+++ b/ranger-atlas-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-kafka-plugin-shim/pom.xml
+++ b/ranger-kafka-plugin-shim/pom.xml
@@ -54,18 +54,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${scala.binary.version}</artifactId>
+            <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>
-          <exclusions>
-                <exclusion>
-                   <groupId>io.netty</groupId>
-                   <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                   <groupId>io.netty</groupId>
-                   <artifactId>netty-transport-native-epoll</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/ranger-kylin-plugin-shim/pom.xml
+++ b/ranger-kylin-plugin-shim/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-presto-plugin-shim/pom.xml
+++ b/ranger-presto-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-sqoop-plugin-shim/pom.xml
+++ b/ranger-sqoop-plugin-shim/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/ranger-trino-plugin-shim/pom.xml
+++ b/ranger-trino-plugin-shim/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>

--- a/storm-agent/pom.xml
+++ b/storm-agent/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.ranger</groupId>
         <artifactId>ranger</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.0.3.3.6.0-1</version>
         <relativePath>..</relativePath>
     </parent>
     <dependencies>


### PR DESCRIPTION
Updated all services and related packages versions as per target versions with below exceptions to avoid circular dependency : 
ozone - 1.4.0 
kafka - 3.7.1 + Backported RANGER-3231 patch to support kafka3
Schema registry - 1.0.1 (failing with 1.0.0)
hive.storage-api.version - 4.0.0 (as per ODP hive project)


Compiled successfully in jdk11 local env.