### PR TITLE
ODP-1095: RANGER-3729|CVE-2020-36518|Upgrade Jackson-core and Jackson-databind

### DIFF
--- a/agents-common/pom.xml
+++ b/agents-common/pom.xml
@@ -100,6 +100,11 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.jackson.databind.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
             <version>${fasterxml.jackson.version}</version>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -55,7 +55,11 @@
         <includes>
           <include>com.sun.jersey:jersey-client:jar:${jersey-bundle.version}</include>
           <include>com.sun.jersey:jersey-core:jar:${jersey-bundle.version}</include>
+          <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
+          <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
           <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:${fasterxml.jackson.version}</include>
+          <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
+          <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:${fasterxml.jackson.version}</include>
           <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
           <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
           <include>org.eclipse.jetty:jetty-client:jar:${jetty-client.version}</include>

--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -87,13 +87,6 @@
                     <include>org.apache.httpcomponents:httpclient:jar:${kms.httpcomponents.httpclient.version}</include>
                     <include>org.noggit:noggit:jar:${noggit.version}</include>
                     <include>org.apache.hadoop:hadoop-hdfs:jar:${hadoop.version}</include>
-                    <include>com.fasterxml.jackson.core:jackson-core</include>
-                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
-                    <include>com.fasterxml.jackson.core:jackson-databind</include>
-                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
-                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
-                    <include>org.codehaus.jackson:jackson-core-asl</include>
-                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
                     <include>org.apache.kerby:kerb-core:jar:${kerby.version}</include>
                     <include>org.apache.kerby:kerb-util:jar:${kerby.version}</include>
                     <include>org.apache.kerby:kerb-crypto:jar:${kerby.version}</include>
@@ -110,7 +103,6 @@
                     <include>com.squareup.retrofit2:retrofit</include>
                     <include>com.squareup.retrofit2:adapter-rxjava</include>
                     <include>com.squareup.okhttp3:okhttp-urlconnection</include>
-                    <include>com.fasterxml.jackson.datatype:jackson-datatype-joda</include>
                     <include>joda-time:okhttp-urlconnection</include>
                     <include>joda-time:joda-time</include>
                     <include>com.nimbusds:oauth2-oidc-sdk</include>
@@ -236,10 +228,12 @@
                     <include>com.google.guava:guava</include>
                     <include>com.google.code.gson:gson</include>
                     <include>com.sun.jersey:jersey-bundle</include>
-                    <include>org.codehaus.jackson:jackson-core-asl</include>
-                    <include>org.codehaus.jackson:jackson-jaxrs</include>
-                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
-                    <include>org.codehaus.jackson:jackson-xc</include>
+                    <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar</include>
+                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
                     <include>org.codehaus.woodstox:stax2-api</include>
                     <include>com.fasterxml.woodstox:woodstox-core</include>
                 </includes>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -67,10 +67,11 @@
 					<include>com.google.guava:guava:jar:${google.guava.version}</include>
 					<include>com.google.protobuf:protobuf-java:jar:${protobuf-java.version}</include>
 					<include>org.noggit:noggit:jar:${noggit.version}</include>
-					<include>org.codehaus.jackson:jackson-core-asl</include>
-					<include>org.codehaus.jackson:jackson-jaxrs</include>
-					<include>org.codehaus.jackson:jackson-mapper-asl</include>
-					<include>org.codehaus.jackson:jackson-xc</include>
+					<include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+					<include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+					<include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
+					<include>com.fasterxml.jackson.core:jackson-databind</include>
+					<include>com.fasterxml.jackson.core:jackson-core</include>
 					<include>org.apache.solr:solr-solrj:jar:${solr.version}</include>
 					<include>commons-codec:commons-codec</include>
 					<include>org.codehaus.woodstox:stax2-api</include>

--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -103,11 +103,12 @@
                     <include>com.sun.jersey:jersey-core</include>
                     <include>com.sun.jersey:jersey-client</include>
                     <include>com.sun.jersey:jersey-bundle</include>
-                    <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
-                    <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.databind.version}</include>
-                    <include>org.codehaus.jackson:jackson-jaxrs</include>
-                    <include>org.codehaus.jackson:jackson-xc</include>
-		            <include>com.sun.xml.bind:jaxb-impl</include>
+                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base</include>
+                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                    <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+                    <include>com.sun.xml.bind:jaxb-impl</include>
                     <include>org.apache.htrace:htrace-core4:jar:${htrace-core.version}</include>
                     <include>commons-lang:commons-lang</include>
                     <include>com.kstruct:gethostname4j</include>

--- a/distro/src/main/assembly/ranger-tools.xml
+++ b/distro/src/main/assembly/ranger-tools.xml
@@ -60,10 +60,10 @@
               <include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>
               <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
               <include>org.noggit:noggit:jar:${noggit.version}</include>
-              <include>org.codehaus.jackson:jackson-core-asl</include>
-              <include>org.codehaus.jackson:jackson-jaxrs</include>
-              <include>org.codehaus.jackson:jackson-mapper-asl</include>
-              <include>org.codehaus.jackson:jackson-xc</include>
+              <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+              <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+              <include>com.fasterxml.jackson.core:jackson-databind</include>
+              <include>com.fasterxml.jackson.core:jackson-core</include>
               <include>org.codehaus.woodstox:stax2-api:jar:${codehaus.woodstox.stax2api.version}</include>
               <include>com.fasterxml.woodstox:woodstox-core:jar:${fasterxml.woodstox.version}</include>
               <include>org.apache.ranger:ranger-plugins-common</include>

--- a/distro/src/main/assembly/sample-client.xml
+++ b/distro/src/main/assembly/sample-client.xml
@@ -58,10 +58,10 @@
                     <include>com.google.guava:guava:jar:${google.guava.version}</include>
                     <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
                     <include>org.noggit:noggit:jar:${noggit.version}</include>
-                    <include>org.codehaus.jackson:jackson-core-asl</include>
-                    <include>org.codehaus.jackson:jackson-jaxrs</include>
-                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
-                    <include>org.codehaus.jackson:jackson-xc</include>
+                    <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                    <include>com.fasterxml.jackson.core:jackson-core</include>
                     <include>org.apache.ranger:ranger-plugins-audit</include>
                     <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
                     <include>net.java.dev.jna:jna:jar:${jna.version}</include>

--- a/kms/pom.xml
+++ b/kms/pom.xml
@@ -54,6 +54,11 @@
             <version>${fasterxml.jackson.databind.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
@@ -283,8 +288,8 @@
             <version>${httpcomponents.httpcore.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-base</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
             <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
@@ -293,8 +298,8 @@
             <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-xml</artifactId>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
             <version>${fasterxml.jackson.version}</version>
         </dependency>
         <dependency>

--- a/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/RangerKeyStore.java
@@ -73,10 +73,10 @@ import org.apache.hadoop.crypto.key.RangerKeyStoreProvider.KeyMetadata;
 import org.apache.ranger.entity.XXRangerKeyStore;
 import org.apache.ranger.kms.dao.DaoManager;
 import org.apache.ranger.kms.dao.RangerKMSDao;
-import org.codehaus.jackson.JsonParseException;
-import org.codehaus.jackson.map.JsonMappingException;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.type.TypeReference;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.4</version>
+            <version>${fasterxml.jackson.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/ranger-examples/distro/src/main/assembly/plugin-sampleapp.xml
+++ b/ranger-examples/distro/src/main/assembly/plugin-sampleapp.xml
@@ -44,10 +44,10 @@
             <include>commons-io:commons-io:jar:${commons.io.version}</include>
             <include>commons-lang:commons-lang:jar:${commons.lang.version}</include>
             <include>com.google.guava:guava:jar:${google.guava.version}</include>
-            <include>org.codehaus.jackson:jackson-jaxrs:jar:${codehaus.jackson.storm.version}</include>
-            <include>org.codehaus.jackson:jackson-core-asl:jar:${codehaus.jackson.storm.version}</include>
-            <include>org.codehaus.jackson:jackson-mapper-asl:jar:${codehaus.jackson.storm.version}</include>
-            <include>org.codehaus.jackson:jackson-xc:jar:${codehaus.jackson.storm.version}</include>
+            <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:${fasterxml.jackson.version}</include>
+            <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:${fasterxml.jackson.version}</include>
+            <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>
+            <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
             <include>org.slf4j:slf4j-api</include>
             <include>log4j:log4j</include>
             <include>com.sun.jersey:jersey-bundle</include>

--- a/ranger-examples/distro/src/main/assembly/sample-client.xml
+++ b/ranger-examples/distro/src/main/assembly/sample-client.xml
@@ -54,10 +54,10 @@
                     <include>com.google.guava:guava:jar:${google.guava.version}</include>
                     <include>org.apache.httpcomponents:httpmime:jar:${httpcomponents.httpmime.version}</include>
                     <include>org.noggit:noggit:jar:${noggit.version}</include>
-                    <include>org.codehaus.jackson:jackson-core-asl</include>
-                    <include>org.codehaus.jackson:jackson-jaxrs</include>
-                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
-                    <include>org.codehaus.jackson:jackson-xc</include>
+                    <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
+                    <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
+                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                    <include>com.fasterxml.jackson.core:jackson-core</include>
                     <include>org.apache.ranger:ranger-plugins-audit</include>
                     <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
                     <include>net.java.dev.jna:jna:jar:${jna.version}</include>


### PR DESCRIPTION
ODP-1095 Critical CVE fixes patch (#6)
* Release tag change to 3.2.2.0-1095

(cherry picked from commit https://github.com/acceldata-io/ranger/commit/7446e6a1)
