### PR TITLE
ODP-1997|ODP-2005|ODP-2006 Updating jars versions to match ozone, kafka, and schema registry project

### DIFF
--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -188,6 +188,7 @@
           <include>org.apache.ozone:hdds-config:jar:${ozone.version}</include>
           <include>org.apache.ozone:hdds-interface-client:jar:${ozone.version}</include>
           <include>org.apache.ozone:ozone-interface-client:jar:${ozone.version}</include>
+          <include>org.apache.ozone:ozone-filesystem-hadoop3:jar:${ozone.version}</include>
           <include>org.apache.ratis:ratis-common:jar:${ratis.version}</include>
           <include>org.apache.ratis:ratis-proto:jar:${ratis.version}</include>
           <include>org.apache.ratis:ratis-thirdparty-misc:jar:${ratis-thirdparty.version}</include>

--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -80,6 +80,7 @@
           <include>org.apache.hive:hive-metastore:jar:${hive.version}</include>
           <include>org.apache.thrift:libfb303:jar:${libfb303.version}</include>
           <include>org.apache.thrift:libthrift:jar:${libthrift.version}</include>
+          <include>com.google.guava:guava:jar:${guava.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -206,6 +206,11 @@
             <artifactId>javax.el</artifactId>
             <version>${javax.el.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
 
         <!-- Test -->
         <dependency>

--- a/plugin-kafka/src/main/java/org/apache/ranger/services/kafka/client/ServiceKafkaConnectionMgr.java
+++ b/plugin-kafka/src/main/java/org/apache/ranger/services/kafka/client/ServiceKafkaConnectionMgr.java
@@ -28,6 +28,8 @@ public class ServiceKafkaConnectionMgr {
 	private static final String KEY_SASL_MECHANISM	= "sasl.mechanism";
 	private static final String KEY_KAFKA_KEYTAB    = "kafka.keytab";
 	private static final String KEY_KAFKA_PRINCIPAL = "kafka.principal";
+	private static final String KEY_KAFKA_KEYTAB    = "kafka.keytab";
+	private static final String KEY_KAFKA_PRINCIPAL = "kafka.principal";
 
 	static public ServiceKafkaClient getKafkaClient(String serviceName,
 													Map<String, String> configs) throws Exception {

--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -133,6 +133,11 @@ limitations under the License.
 	        <version>${ozone.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.ozone</groupId>
+            <artifactId>ozone-filesystem-hadoop3</artifactId>
+            <version>${ozone.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.version}</version>

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <avro.version>1.11.3</avro.version>
         <jersey.version>2.22.1</jersey.version>
-        <schema.registry.version>0.9.1</schema.registry.version>
+        <schema.registry.version>1.0.1</schema.registry.version>
         <jettison.version>1.5.4</jettison.version>
         <servlet-api.version>3.0.1</servlet-api.version>
         <snakeyaml.version>2.2</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <commons.cli.version>1.2</commons.cli.version>
         <commons.codec.version>1.15</commons.codec.version>
         <commons.collections.version>3.2.2</commons.collections.version>
-        <commons.compress.version>1.26.2</commons.compress.version>
+        <commons.compress.version>1.21</commons.compress.version>
         <commons.configuration1.version>1.10</commons.configuration1.version>
         <commons.configuration.version>2.8.0</commons.configuration.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
@@ -165,7 +165,7 @@
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <kafka.version>2.8.2</kafka.version>
         <kerby.version>2.0.3</kerby.version>
-        <schema.registry.version>1.0.0</schema.registry.version>
+        <schema.registry.version>1.0.1</schema.registry.version>
         <junit.version>4.13.1</junit.version>
         <knox.gateway.version>2.0.0</knox.gateway.version>
         <kylin.version>4.0.4</kylin.version>
@@ -192,8 +192,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf-java.version>3.19.6</protobuf-java.version>
         <gcp.protobuf-java.version>3.19.6</gcp.protobuf-java.version>
-        <ratis.version>2.1.0</ratis.version>
-        <ratis-thirdparty.version>0.7.0</ratis-thirdparty.version>
+        <ratis.version>3.0.1</ratis.version>
+        <ratis-thirdparty.version>1.0.5</ratis-thirdparty.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.xml.version>1.0.4</scala.xml.version>
@@ -243,8 +243,8 @@
         <com.microsoft.azure.adal4j.version>1.6.4</com.microsoft.azure.adal4j.version>
         <io.reactivex.rxjava.version>1.3.8</io.reactivex.rxjava.version>
         <net.minidev.asm.version>1.0.2</net.minidev.asm.version>
-        <org.bouncycastle.bcprov-jdk15on>1.70</org.bouncycastle.bcprov-jdk15on>
-        <org.bouncycastle.bcpkix-jdk15on>1.70</org.bouncycastle.bcpkix-jdk15on>
+        <org.bouncycastle.bcprov-jdk15on>1.67</org.bouncycastle.bcprov-jdk15on>
+        <org.bouncycastle.bcpkix-jdk15on>1.67</org.bouncycastle.bcpkix-jdk15on>
         <lucene.version>8.11.3</lucene.version>
         <hppc.version>0.8.0</hppc.version>
         <joda.time.version>2.10.6</joda.time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <graalvm.version>22.3.0</graalvm.version>
         <gson.version>2.9.0</gson.version>
         <guice.version>4.0</guice.version>
+        <guava.version>32.0.1-jre</guava.version>
         <hadoop-shaded-guava.version>1.1.1</hadoop-shaded-guava.version>
         <hadoop.version>3.3.6.3.3.6.0-1</hadoop.version>
         <ozone.version>1.4.0</ozone.version>
@@ -132,7 +133,7 @@
         <hbase-shaded-protobuf>4.1.7</hbase-shaded-protobuf>
         <hbase-shaded-netty>4.1.7</hbase-shaded-netty>
         <hbase-shaded-miscellaneous>4.1.7</hbase-shaded-miscellaneous>
-        <libthrift.version>0.14.0</libthrift.version>
+        <libthrift.version>0.16.0</libthrift.version>
         <htrace-core.version>4.1.0-incubating</htrace-core.version>
         <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
         <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version>


### PR DESCRIPTION
ODP-1997 Fix missing jars and update jar versions in ozone plugin to match ozone project
ODP-2005 Fix missing jars in ranger kafka plugin
ODP-2006 Updating jars versions to match schema registry project

Tested locally.