### PR TITLE
ODP-1998 Ranger setup.sh/db setup fails on Mysql ranger creation fix

### DIFF
--- a/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
+++ b/security-admin/db/mysql/optimized/current/ranger_core_db_mysql.sql
@@ -456,7 +456,7 @@ CREATE TABLE `x_trx_log_v2` (
   KEY `x_trx_log_v2_FK_added_by_id` (`added_by_id`),
   KEY `x_trx_log_v2_cr_time` (`create_time`),
   KEY `x_trx_log_v2_trx_id` (`trx_id`)
-)ROW_FORMAT=DYNAMIC;
+)DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE `x_perm_map` (
   `id` bigint(20) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
ODP-1998 Ranger setup.sh/db setup fails on Mysql ranger creation

Tested on local env.