### PR TITLE
ODP-2082|RANGER-4201 Fix Hbase master start issue due to ranger-hbase-plugin jersey jar class loading order

### DIFF
--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -110,6 +110,9 @@
             <include>io.opentelemetry:opentelemetry-context:jar:${io.opentelemetry.version}</include>
             <include>io.opentelemetry:opentelemetry-semconv:jar:${io.opentelemetry-semconv.version}</include>
             <include>io.dropwizard.metrics:metrics-core</include>
+            <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
+            <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
+            <include>org.apache.hadoop:hadoop-client-runtime</include>
         </includes>
       </binaries>
     </moduleSet>
@@ -189,6 +192,7 @@
           <include>org.apache.ozone:hdds-interface-client:jar:${ozone.version}</include>
           <include>org.apache.ozone:ozone-interface-client:jar:${ozone.version}</include>
           <include>org.apache.ozone:ozone-filesystem-hadoop3:jar:${ozone.version}</include>
+          <include>org.apache.ozone:ozone-filesystem-hadoop3-client:jar:${ozone.version}</include>
           <include>org.apache.ratis:ratis-common:jar:${ratis.version}</include>
           <include>org.apache.ratis:ratis-proto:jar:${ratis.version}</include>
           <include>org.apache.ratis:ratis-thirdparty-misc:jar:${ratis-thirdparty.version}</include>
@@ -350,6 +354,7 @@
         <fileMode>644</fileMode>
         <includes>
           <include>org.apache.ranger:ranger-kafka-plugin</include>
+          <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:${hadoop-shaded-guava.version}</include>
         </includes>
       </binaries>
     </moduleSet>

--- a/distro/src/main/assembly/hbase-agent.xml
+++ b/distro/src/main/assembly/hbase-agent.xml
@@ -54,7 +54,6 @@
         <fileMode>644</fileMode>
         <includes>
           <include>com.sun.jersey:jersey-client:jar:${jersey-bundle.version}</include>
-          <include>com.sun.jersey:jersey-core:jar:${jersey-bundle.version}</include>
           <include>com.fasterxml.jackson.core:jackson-annotations:jar:${fasterxml.jackson.version}</include>
           <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
           <include>com.fasterxml.jackson.core:jackson-databind:jar:${fasterxml.jackson.version}</include>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <hadoop.version>3.3.6.3.3.6.0-1</hadoop.version>
         <ozone.version>1.4.0.3.3.6.0-1</ozone.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <hbase.version>2.5.8.3.3.6.0-1</hbase.version>
+        <hbase.version>2.6.0</hbase.version>
         <hive.version>4.0.0.3.3.6.0-1</hive.version>
         <hive.storage-api.version>2.7.2</hive.storage-api.version>
         <orc.version>1.5.8</orc.version>


### PR DESCRIPTION
ODP-2082 Fix Hbase master start issue due to ranger-hbase-plugin jersey jar class loading order by applying RANGER-4201 patch.

Patch tested locally on clusters with : 
1. ranger + kerberos
2.  ranger + kerberos + SSL on hbase