### PR TITLE
RANGER-4916: Before redirect check and remove index.html

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerSSOAuthenticationFilter.java
+++ b/security-admin/src/main/java/org/apache/ranger/security/web/filter/RangerSSOAuthenticationFilter.java
@@ -269,7 +269,7 @@ public class RangerSSOAuthenticationFilter implements Filter {
 			// then need to redirect user to the login page.
 			String url = ((HttpServletRequest) servletRequest).getRequestURI() ;
 			if (!url.contains("login.jsp")) {
-				url = url + "login.jsp";
+				url = url.replace("backbone-index.html", "").replace("index.html", "") + "login.jsp";
 			}
 			// invalidating session
 			if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

[RANGER-4916](https://issues.apache.org/jira/browse/RANGER-4916): Before redirect check and remove index.html [#376](https://github.com/apache/ranger/pull/376)

Sometimes when the session gets timed-out the page does not redirect to the "login.jsp" page, it's instead gets stuck on "/index.htmllogin.jsp#/policymanager/resource"
<img width="100%" alt="Screenshot 2024-08-22 at 8 23 45 AM" src="https://github.com/user-attachments/assets/598e7d1b-0642-473d-a5c1-ae96d28dac3d">



## How was this patch tested?

This was tested manually. Steps to repro:
 - Login into ranger UI
 - Either wait for the session to time out or manually delete "RANGERADMINSESSIONID" cookie, the page should get redirected to the right URL
