### PR TITLE
ODP-1859 Added ozone-filesystem-hadoop3-client jar dependency in ozone-plugin

### DIFF
--- a/plugin-ozone/pom.xml
+++ b/plugin-ozone/pom.xml
@@ -138,6 +138,11 @@ limitations under the License.
             <version>${ozone.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.ozone</groupId>
+            <artifactId>ozone-filesystem-hadoop3-client</artifactId>
+            <version>${ozone.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.version}</version>


### PR DESCRIPTION
ODP-1859 Added ozone-filesystem-hadoop3-client jar dependency in ozone-plugin to import it in ranger distro. This commit is follow-up of ODP-1859 fix in https://github.com/acceldata-io/ranger/commit/c9c02f5a50c7d02aa76040e0de42d69a24e2fd3b 


Patch tested on local build. Missing jar is now reflecting in ranger-admin/ews/webapp/WEB-INF/classes/ranger-plugins/ozone/