### PR TITLE
ODP-1456: Enable kudu plugin in ranger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,7 @@
                 <module>plugin-ozone</module>
                 <module>security-admin</module>
                 <module>plugin-kafka</module>
+                <module>plugin-kudu</module>
                 <module>plugin-solr</module>
                 <module>plugin-nifi</module>
                 <module>plugin-nifi-registry</module>
@@ -513,6 +514,19 @@
                 <module>ranger-kafka-plugin-shim</module>
             </modules>
         </profile>
+         <profile>
+            <id>ranger-kudu-plugin</id>
+            <modules>
+                <module>agents-audit</module>
+                <module>agents-common</module>
+                <module>agents-cred</module>
+                <module>agents-installer</module>
+                <module>credentialbuilder</module>
+                <module>ranger-plugin-classloader</module>
+                <module>ranger-util</module>
+                <module>plugin-kudu</module>
+            </modules>
+        </profile>
         <profile>
             <id>ranger-solr-plugin</id>
             <modules>
@@ -652,9 +666,9 @@
                 <module>plugin-yarn</module>
                 <module>plugin-ozone</module>
                 <module>plugin-kafka</module>
+                <module>plugin-kudu</module>
                 <!--<module>plugin-nifi</module>
-                <module>plugin-nifi-registry</module>
-                <module>plugin-kudu</module>-->
+                <module>plugin-nifi-registry</module>-->
                 <module>ugsync-util</module>
                 <module>ugsync</module>
                 <module>ugsync/ldapconfigchecktool/ldapconfigcheck</module>
@@ -736,6 +750,7 @@
                 <module>plugin-ozone</module>
                 <module>security-admin</module>
                 <module>plugin-kafka</module>
+                <module>plugin-kudu</module>
                 <module>plugin-solr</module>
                 <!--<module>plugin-nifi</module>
                 <module>plugin-nifi-registry</module>


### PR DESCRIPTION
This adds the Kudu plugin to ranger so that the Acceldata version of Ranger supports Kudu.

With this change, building it locally includes the required jar file:
```[root@ce02 ranger]# find . -name "*kudu*.jar" -type f
./plugin-kudu/target/ranger-kudu-plugin-2.3.0.3.2.3.2-2.jar```