### PR TITLE
ODP-2274 : Fix jackson-core version in kms

### DIFF
--- a/distro/src/main/assembly/kms.xml
+++ b/distro/src/main/assembly/kms.xml
@@ -231,7 +231,7 @@
                     <include>com.fasterxml.jackson.module:jackson-module-jaxb-annotations</include>
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider</include>
                     <include>com.fasterxml.jackson.core:jackson-databind</include>
-                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                    <include>com.fasterxml.jackson.core:jackson-core:jar:${fasterxml.jackson.version}</include>
                     <include>com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar</include>
                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                     <include>org.codehaus.woodstox:stax2-api</include>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hbase.jetty.version>9.3.27.v20190418</hbase.jetty.version>
-        <hadoop.version>3.2.3.3.2.3.0-SNAPSHOT</hadoop.version>
+        <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/hive-agent/pom.xml
+++ b/hive-agent/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <hadoop.version>3.2.3.3.2.3.0-SNAPSHOT</hadoop.version>
+        <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.apache.tez</groupId>
             <artifactId>tez-dag</artifactId>
-            <version>0.10.1.3.2.3.0-SNAPSHOT</version>
+            <version>0.10.1.3.2.3.2-2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/plugin-schema-registry/pom.xml
+++ b/plugin-schema-registry/pom.xml
@@ -32,7 +32,7 @@
     </parent>
 
     <properties>
-        <hadoop.version>3.2.3.3.2.3.0-SNAPSHOT</hadoop.version>
+        <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
         <jersey.version>2.22.1</jersey.version>
         <jettison.version>1.1</jettison.version>
         <servlet-api.version>3.0.1</servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -117,12 +117,12 @@
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>
         <gson.version>2.2.4</gson.version>
         <guice.version>4.0</guice.version>
-        <hadoop.version>3.2.3.3.2.3.0-SNAPSHOT</hadoop.version>
-        <ozone.version>1.4.0.3.2.3.0-SNAPSHOT</ozone.version>
+        <hadoop.version>3.2.3.3.2.3.2-2</hadoop.version>
+        <ozone.version>1.4.0.3.2.3.2-2</ozone.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <hbase.version>2.4.11.3.2.3.0-SNAPSHOT</hbase.version>
-        <hive.version>3.1.4.3.2.3.0-SNAPSHOT</hive.version>
-        <hive.storage-api.version>3.1.4.3.2.3.0-SNAPSHOT</hive.storage-api.version>
+        <hbase.version>2.4.11.3.2.3.2-2</hbase.version>
+        <hive.version>3.1.4.3.2.3.2-2</hive.version>
+        <hive.storage-api.version>3.1.4.3.2.3.2-2</hive.storage-api.version>
         <orc.version>1.5.8</orc.version>
         <hbase-shaded-protobuf>3.3.0</hbase-shaded-protobuf>
         <hbase-shaded-netty>3.3.0</hbase-shaded-netty>
@@ -156,9 +156,9 @@
         <jsr250.version>1.0</jsr250.version>
         <jsr305.version>1.3.9</jsr305.version>
         <junit.version>4.13.1</junit.version>
-        <kafka.version>2.8.2.3.2.3.0-SNAPSHOT</kafka.version>
+        <kafka.version>2.8.2.3.2.3.2-2</kafka.version>
         <kerby.version>2.0.3</kerby.version>
-        <knox.gateway.version>1.6.1.3.2.3.0-SNAPSHOT</knox.gateway.version>
+        <knox.gateway.version>1.6.1.3.2.3.2-2</knox.gateway.version>
         <schema.registry.version>1.0.1</schema.registry.version>
         <kylin.version>3.1.3</kylin.version>
         <libpam4j.version>1.10</libpam4j.version    >
@@ -203,7 +203,7 @@
         <tomcat.embed.version>8.5.78</tomcat.embed.version>
         <testng.version>6.9.4</testng.version>
         <velocity.version>2.3</velocity.version>
-        <zookeeper.version>3.5.10.3.2.3.0-SNAPSHOT</zookeeper.version>
+        <zookeeper.version>3.5.10.3.2.3.2-2</zookeeper.version>
         <codehaus.woodstox.stax2api.version>4.2.1</codehaus.woodstox.stax2api.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version>
         <fasterxml.jackson.version>2.12.7</fasterxml.jackson.version>


### PR DESCRIPTION
ODP-2274 : Fix jackson-core version in kms

Tested to 3.2.3.2-202 release which needed this fix, refer ticket for more info