### PR TITLE
ODP-2701 Fix NoClassDefFoundError  when creating ranger cred.jceks

### DIFF
--- a/distro/src/main/assembly/plugin-ozone.xml
+++ b/distro/src/main/assembly/plugin-ozone.xml
@@ -55,6 +55,7 @@
                     <include>commons-collections:commons-collections</include>
                     <include>commons-io:commons-io:jar:${commons.io.version}</include>
                     <include>commons-lang:commons-lang</include>
+                    <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>
                     <include>commons-logging:commons-logging:jar:${commons.logging.version}</include>
                     <include>com.google.guava:guava:jar:${google.guava.version}</include>
                     <include>org.slf4j:slf4j-api:jar:${slf4j-api.version}</include>


### PR DESCRIPTION
ODP-2701 Fix NoClassDefFoundError: org.apache.commons.lang3.StringUtils when creating ranger cred.jceks