### PR TITLE
ODP-3602 : Removed try-catch block for ExecutionException in EagerKeyGeneratorKeyProviderCryptoExtension.java

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/EagerKeyGeneratorKeyProviderCryptoExtension.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/EagerKeyGeneratorKeyProviderCryptoExtension.java
@@ -104,14 +104,9 @@ public class EagerKeyGeneratorKeyProviderCryptoExtension
     }
 
     @Override
-    public void warmUpEncryptedKeys(String... keyNames) throws
-                                                        IOException {
-      try {
-        encKeyVersionQueue.initializeQueuesForKeys(keyNames);
-      } catch (ExecutionException e) {
-        throw new IOException(e);
-      }
-    }
+    public void warmUpEncryptedKeys(String... keyNames) throws IOException {
+      encKeyVersionQueue.initializeQueuesForKeys(keyNames);
+    }  
 
     @Override
     public void drain(String keyName) {


### PR DESCRIPTION
This patch was tested locally.