### PR TITLE
ODP-3190: Add a message to the Kudu connection test

### DIFF
--- a/plugin-kudu/src/main/java/org/apache/ranger/services/kudu/RangerServiceKudu.java
+++ b/plugin-kudu/src/main/java/org/apache/ranger/services/kudu/RangerServiceKudu.java
@@ -20,6 +20,7 @@ package org.apache.ranger.services.kudu;
 
 import org.apache.ranger.plugin.service.RangerBaseService;
 import org.apache.ranger.plugin.service.ResourceLookupContext;
+import org.apache.ranger.plugin.client.BaseClient;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,12 +30,14 @@ import java.util.List;
  * RangerService for Apache Kudu.
  */
 public class RangerServiceKudu extends RangerBaseService {
-
-    @Override
-    public HashMap<String, Object> validateConfig() throws Exception {
-      // TODO: implement configure validation for Kudu policies.
-      return new HashMap<>();
+	@Override
+    public HashMap<String, Object> validateConfig(){
+      HashMap<String, Object> responseData = new HashMap<String, Object>();
+      String message = "Currently unimplemented. This can be safely ignored.";
+      BaseClient.generateResponseDataMap(false, message, message, null, null, responseData);
+      return responseData;
     }
+
 
     @Override
     public List<String> lookupResource(ResourceLookupContext context) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Previously, if you ran the connection test for the Kudu plugin, it would tell you that the connection failed. This was due to nothing being implemented. This adds a message that says the result of the test can be safely ignored since it is not implemented.

## How was this patch tested?
This was tested manually.
<img width="549" alt="image" src="https://github.com/user-attachments/assets/91b1d352-5d34-458d-818b-2c621c0ce07e" />
