### PR TITLE
ODP-3062: Updated try-catch block to catch IOException in EagerKeyGen…

### DIFF
--- a/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/EagerKeyGeneratorKeyProviderCryptoExtension.java
+++ b/kms/src/main/java/org/apache/hadoop/crypto/key/kms/server/EagerKeyGeneratorKeyProviderCryptoExtension.java
@@ -108,7 +108,7 @@ public class EagerKeyGeneratorKeyProviderCryptoExtension
                                                         IOException {
       try {
         encKeyVersionQueue.initializeQueuesForKeys(keyNames);
-      } catch (ExecutionException e) {
+      } catch (IOException e) {
         throw new IOException(e);
       }
     }


### PR DESCRIPTION
This patch was tested locally.