### PR TITLE
ODP-4078 Add missing hadoop-hdfs-client required for Ranger HDFS audits

### DIFF
--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -81,6 +81,29 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs-client</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>${httpcomponents.httpcore.version}</version>


### PR DESCRIPTION
ODP-4078 Add missing hadoop-hdfs-client required for Ranger HDFS auditing.

To implement Ranger HDFS Auditing in Kafka, the following hdfs jars are required.
`hadoop-hdfs.jar
hadoop-common.jar 
hadoop-auth.jar
hadoop-hdfs-client.jar `
These were added as part of ODP-2322, but hadoop-hdfs-client.jar was still not populating.

Current PR addresses missing `hadoop-hdfs-client` jar. 
The patch is tested and validated against a local RHEL9 build.
