### PR TITLE
ODP-4078 Add missing hadoop-client-runtime required for Ranger HDFS a…

### DIFF
--- a/plugin-kafka/pom.xml
+++ b/plugin-kafka/pom.xml
@@ -82,6 +82,29 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs-client</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>


### PR DESCRIPTION
ODP-4078 Add the missing hadoop-client-runtime jar required for Ranger HDFS auditing. This jar is only required against Hadoop 3.3.6.

While testing Ranger HDFS Auditing in Kafka with HDFS 3.3.6.3.3.6.1-1, the following hdfs jars are required.
`hadoop-client-runtime
hadoop-hdfs-client.jar `
These were added as part of ODP-2322, but hadoop-client-runtime.jar was still not populating.

Current PR addresses missing `hadoop-client-runtime` jar. 
The patch is tested and validated against a local RHEL9 build.
