### PR TITLE
ODP-3682 Add default ranger policies for Schema Registry

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-schema-registry.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-schema-registry.json
@@ -179,6 +179,28 @@
   [
     {
       "itemId": 1,
+      "name": "username",
+      "type": "string",
+      "mandatory": true,
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Username"
+    },
+
+    {
+      "itemId": 2,
+      "name": "password",
+      "type": "password",
+      "mandatory": true,
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "Password"
+    },
+
+    {
+      "itemId": 3,
       "name": "schema.registry.url",
       "type": "string",
       "mandatory": true,
@@ -190,7 +212,7 @@
     },
 
     {
-      "itemId": 2,
+      "itemId": 4,
       "name": "schema-registry.authentication",
       "type": "enum",
       "subType": "authType",
@@ -203,7 +225,7 @@
     },
 
     {
-      "itemId": 3,
+      "itemId": 5,
       "name": "commonNameForCertificate",
       "type": "string",
       "mandatory": false,
@@ -214,7 +236,7 @@
     },
 
     {
-      "itemId": 4,
+      "itemId": 6,
       "name": "ranger.plugin.audit.filters",
       "type": "string",
       "subType": "",
@@ -225,7 +247,6 @@
       "label": "Ranger Default Audit Filters",
       "defaultValue": "[]"
     }
-
   ],
 
   "enums":

--- a/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
+++ b/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
@@ -108,7 +108,6 @@ public class RangerServiceSchemaRegistry extends RangerBaseService {
                 RangerPolicy.RangerPolicyItem policyItemForLookupUser = new RangerPolicy.RangerPolicyItem();
                 List<RangerPolicy.RangerPolicyItemAccess> accessListForLookupUser = new ArrayList<>();
                 accessListForLookupUser.add(new RangerPolicy.RangerPolicyItemAccess(ACCESS_TYPE_READ));
-                accessListForLookupUser.add(new RangerPolicy.RangerPolicyItemAccess(ACCESS_TYPE_ALL));
                 policyItemForLookupUser.setUsers(Collections.singletonList(lookUpUser));
                 policyItemForLookupUser.setAccesses(accessListForLookupUser);
                 policyItemForLookupUser.setDelegateAdmin(false);

--- a/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
+++ b/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
@@ -28,7 +28,13 @@ import org.apache.ranger.plugin.service.ResourceLookupContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Collections;
+
+//import java.util.*;
 
 import static org.apache.ranger.plugin.policyengine.RangerPolicyEngine.GROUP_PUBLIC;
 

--- a/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
+++ b/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
@@ -38,7 +38,6 @@ public class RangerServiceSchemaRegistry extends RangerBaseService {
     public static final String ACCESS_TYPE_UPDATE = "update";
     public static final String ACCESS_TYPE_READ  = "read";
     public static final String ACCESS_TYPE_DELETE = "delete";
-    public static final String ACCESS_TYPE_ALL    = "all";
 
     private static final Logger LOG = LoggerFactory.getLogger(RangerServiceSchemaRegistry.class);
 

--- a/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
+++ b/plugin-schema-registry/src/main/java/org/apache/ranger/services/schema/registry/RangerServiceSchemaRegistry.java
@@ -34,8 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Collections;
 
-//import java.util.*;
-
 import static org.apache.ranger.plugin.policyengine.RangerPolicyEngine.GROUP_PUBLIC;
 
 public class RangerServiceSchemaRegistry extends RangerBaseService {


### PR DESCRIPTION
ODP-3682 Add default Ranger policies for Schema Registry. The following changes create five default policies based on resources available as per Schema Registry serviceDef. In each default policy, service level user is given admin access while rangerlookup user is given read type access.

Additionally, https://github.com/acceldata-io/ambari-mpacks/pull/229 patch is required to automatically pass the correct username and password from Ambari at the time of Ranger Schema Registry service creation.


Changes tested on local env. 