### PR TITLE
Fix nifi registry service creation null pointer

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-nifi-registry.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-nifi-registry.json
@@ -147,6 +147,28 @@
       "validationMessage":"",
       "uiHint":"",
       "label":"Truststore Password"
+    },
+    {
+      "itemId":560,
+      "name":"commonNameForCertificate",
+      "type":"string",
+      "mandatory":false,
+      "defaultValue":"",
+      "validationRegEx":"",
+      "validationMessage":"",
+      "uiHint":"",
+      "label":"Common Name For Certificate"
+    },
+    {
+      "itemId":570,
+      "name":"ambari.service.check.user",
+      "type":"string",
+      "mandatory":false,
+      "defaultValue":"",
+      "validationRegEx":"",
+      "validationMessage":"",
+      "uiHint":"",
+      "label":"Service Check User"
     }
   ],
   "enums":

--- a/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
@@ -3502,7 +3502,16 @@ public class ServiceDBStore extends AbstractServiceStore {
 		
 		List<XXServiceConfigDef> svcConfDefList = daoMgr.getXXServiceConfigDef()
 				.findByServiceDefName(service.getType());
+		if (svcConfDefList == null) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("No service config definitions found for service type: " + service.getType());
+			}
+			svcConfDefList = new ArrayList<>();
+		}
 		for(XXServiceConfigDef svcConfDef : svcConfDefList ) {
+			if (svcConfDef == null) {
+				continue; // Skip null config definitions
+			}
 			String confField = configs.get(svcConfDef.getName());
 			
 			if(svcConfDef.getIsMandatory() && stringUtil.isEmpty(confField)) {


### PR DESCRIPTION
Add missing configuration parameters to NiFi Registry service definition and improve null safety in service configuration validation.

The original issue was a `NullPointerException` during Ranger service creation because the service configuration included parameters (`commonNameForCertificate`, `ambari.service.check.user`) that were not defined in the NiFi Registry service definition. This PR addresses this by explicitly defining these parameters (as optional) and by adding robust null checks in the validation logic to prevent similar NPEs if service definitions are incomplete or unexpected configurations are provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6ac0b58-1c5a-4334-92fb-073f2130dac6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6ac0b58-1c5a-4334-92fb-073f2130dac6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

