### PR TITLE
OSV-11108|OSV-11268 Address CVEs from elasticsearch and netty

### DIFF
--- a/distro/src/main/assembly/plugin-yarn.xml
+++ b/distro/src/main/assembly/plugin-yarn.xml
@@ -63,13 +63,13 @@
           <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
           <include>net.java.dev.jna:jna:jar:${jna.version}</include>
           <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
-          <include>org.elasticsearch:elasticsearch</include>
+          <!--include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>
           <include>org.elasticsearch.client:elasticsearch-rest-client</include>
           <include>org.elasticsearch.client:elasticsearch-rest-high-level-client</include>
           <include>org.elasticsearch.plugin:rank-eval-client</include>
-          <include>org.elasticsearch.plugin:lang-mustache-client</include>
+          <include>org.elasticsearch.plugin:lang-mustache-client</include-->
           <include>org.apache.httpcomponents:httpcore-nio:jar:${httpcomponents.httpcore.version}</include>
           <include>org.apache.httpcomponents:httpasyncclient:jar:${httpcomponents.httpasyncclient.version}</include>
           <include>org.apache.lucene:lucene-core</include>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <mockito.version>3.0.0</mockito.version>
         <mockito.all.version>1.10.19</mockito.all.version>
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
-        <netty-all.version>4.1.127.Final</netty-all.version>
+        <netty-all.version>4.1.130.Final</netty-all.version>
         <noggit.version>0.8</noggit.version>
         <orc.core.version>1.6.7</orc.core.version>
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>


### PR DESCRIPTION
OSV-11108 Drop elasticsearch jars from yarn plugin packaging as elasticsearch is not maintained in ODP Ranger.
OSV-11268 Bump up Netty to 4.1.130.Final to resolve CVE-2025-59419