### PR TITLE
ODP-6188 [3.3.6.4-1] : Update Ranger S3 plugin to use custom IAM endpoint

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-s3.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-s3.json
@@ -125,6 +125,18 @@
       "validationMessage": "",
       "uiHint":"",
       "label": "Bucket Name"
+    },
+    {
+      "itemId": 7,
+      "name": "aws_s3",
+      "type": "bool",
+      "subType": "YesTrue:NoFalse",
+      "mandatory": true,
+      "validationRegEx":"",
+      "validationMessage": "",
+      "uiHint":"",
+      "label": "AWS S3",
+      "defaultValue": "true"
     }
   ],
 

--- a/s3-agent/pom.xml
+++ b/s3-agent/pom.xml
@@ -33,6 +33,31 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
+<dependency>
+            <groupId>com.adobe.testing</groupId>
+            <artifactId>s3mock-junit5</artifactId>
+            <version>2.2.3</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Exclude extra AWS SDK HTTP client implementations to avoid
+                     "Multiple HTTP implementations found on classpath" error.
+                     url-connection-client is used via the main AWS SDK dependencies. -->
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -62,6 +87,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>iam</artifactId>
             <version>${aws-java-sdk2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+            <version>${aws-java-sdk2.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/s3-agent/pom.xml
+++ b/s3-agent/pom.xml
@@ -33,41 +33,38 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
-<dependency>
+        <dependency>
             <groupId>com.adobe.testing</groupId>
             <artifactId>s3mock-junit5</artifactId>
             <version>2.2.3</version>
             <scope>test</scope>
             <exclusions>
-                <!-- Exclude extra AWS SDK HTTP client implementations to avoid
-                     "Multiple HTTP implementations found on classpath" error.
-                     url-connection-client is used via the main AWS SDK dependencies. -->
-                <exclusion>
-                    <groupId>software.amazon.awssdk</groupId>
-                    <artifactId>apache-client</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>software.amazon.awssdk</groupId>
                     <artifactId>netty-nio-client</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
             <version>2.35.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.databind.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-plugins-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
@@ -88,12 +85,12 @@
             <artifactId>iam</artifactId>
             <version>${aws-java-sdk2.version}</version>
         </dependency>
+
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>url-connection-client</artifactId>
             <version>${aws-java-sdk2.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/s3-agent/src/main/java/org/apache/ranger/services/s3/RangerS3Constants.java
+++ b/s3-agent/src/main/java/org/apache/ranger/services/s3/RangerS3Constants.java
@@ -22,6 +22,7 @@ package org.apache.ranger.services.s3;
 public class RangerS3Constants {
     public static final String S3 = "s3";
     public static final String AWS = "AWS";
+    public static final String AWS_S3 = "aws_s3";
     public static final String ALLOW = "Allow";
     public static final String DENY = "Deny";
     public static final String S3_POLICY_LANGUAGE_VERSION = "2012-10-17";

--- a/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
+++ b/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
@@ -41,7 +41,7 @@ public class S3ClientConnectionMgr extends BaseClient {
     }
 
     public static Map<String, Object> connectionTest(String serviceName, Map<String, String> configs) {
-        LOG.debug("==> S3ClientConnectionMgr.connectionTest ServiceName: "+ serviceName + "Configs" + configs );
+        LOG.debug("==> S3ClientConnectionMgr.connectionTest ServiceName: " + serviceName + "Configs" + configs);
         boolean connectivityStatus = false;
         Map<String, Object> responseData = new HashMap<String, Object>();
         // String bucketName = "odp-ranger-test";
@@ -75,27 +75,30 @@ public class S3ClientConnectionMgr extends BaseClient {
             LOG.error("<== S3ClientConnectionMgr.testConnection Error: " + e.getMessage(), e);
         }
 
-            /*ListBucketsRequest listBucketsRequest = ListBucketsRequest.builder().build();
-            ListBucketsResponse listBucketsResponse = s3.listBuckets(listBucketsRequest);
+        /*
+         * ListBucketsRequest listBucketsRequest = ListBucketsRequest.builder().build();
+         * ListBucketsResponse listBucketsResponse = s3.listBuckets(listBucketsRequest);
+         * 
+         * if (listBucketsResponse != null) {
+         * connectivityStatus = true;
+         * String successMsg = "ConnectionTest Successful";
+         * generateResponseDataMap(connectivityStatus, successMsg, successMsg,
+         * null, null, responseData);
+         * } else {
+         * String failureMsg = "Unable to connect to S3 using given parameters.";
+         * generateResponseDataMap(connectivityStatus, failureMsg, failureMsg,
+         * null, null, responseData);
+         * }
+         * } catch (S3Exception e) {
+         * String failureMsg = "Unable to connect to S3 using given parameters.";
+         * generateResponseDataMap(connectivityStatus, failureMsg, failureMsg,
+         * null, null, responseData);
+         * LOG.error("<== S3ClientConnectionMgr.testConnection Error: " +
+         * e.getMessage(), e);
+         * }
+         */
 
-            if (listBucketsResponse != null) {
-                connectivityStatus = true;
-                String successMsg = "ConnectionTest Successful";
-                generateResponseDataMap(connectivityStatus, successMsg, successMsg,
-                        null, null, responseData);
-            } else {
-                String failureMsg = "Unable to connect to S3 using given parameters.";
-                generateResponseDataMap(connectivityStatus, failureMsg, failureMsg,
-                        null, null, responseData);
-            }
-        } catch (S3Exception e) {
-            String failureMsg = "Unable to connect to S3 using given parameters.";
-            generateResponseDataMap(connectivityStatus, failureMsg, failureMsg,
-                    null, null, responseData);
-            LOG.error("<== S3ClientConnectionMgr.testConnection Error: " + e.getMessage(),  e);
-        } */
-
-        LOG.debug("<== S3ClientConnectionMgr.connectionTest Result : "+ responseData  );
+        LOG.debug("<== S3ClientConnectionMgr.connectionTest Result : " + responseData);
         return responseData;
     }
 
@@ -116,10 +119,23 @@ public class S3ClientConnectionMgr extends BaseClient {
     public static IamClient getIamClient(Map<String, String> configs) {
         String accessKey = configs.get(RangerS3Constants.ACCESS_KEY);
         String secretKey = configs.get(RangerS3Constants.SECRET_KEY);
+        String awsS3Str  = configs.get(RangerS3Constants.AWS_S3);
+        String endpoint = configs.get(RangerS3Constants.ENDPOINT);
+        boolean isAwsS3  = awsS3Str == null || Boolean.parseBoolean(awsS3Str);
+
         AwsBasicCredentials awsCreds3 = AwsBasicCredentials.create(accessKey, secretKey);
-        return IamClient.builder()
+
+        if (isAwsS3) {
+            return IamClient.builder()
                 .region(Region.AWS_GLOBAL)
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds3))
                 .build();
+        } else {
+            // For non-AWS / S3-compatible environments, build IAM client using the endpoint provided in Ranger S3 service configs.
+            return IamClient.builder()
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCreds3))
+                .build();
+        }
     }
 }

--- a/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
+++ b/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.iam.IamClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.*;
 
 public class S3ClientConnectionMgr extends BaseClient {
@@ -78,7 +79,7 @@ public class S3ClientConnectionMgr extends BaseClient {
         /*
          * ListBucketsRequest listBucketsRequest = ListBucketsRequest.builder().build();
          * ListBucketsResponse listBucketsResponse = s3.listBuckets(listBucketsRequest);
-         * 
+         *
          * if (listBucketsResponse != null) {
          * connectivityStatus = true;
          * String successMsg = "ConnectionTest Successful";
@@ -113,6 +114,7 @@ public class S3ClientConnectionMgr extends BaseClient {
                 .region(region)
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds3))
                 .endpointOverride(URI.create(endPointOCE))
+                .serviceConfiguration(S3Configuration.builder().pathStyleAccessEnabled(true).build())
                 .build();
     }
 

--- a/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
+++ b/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
@@ -45,9 +45,17 @@ public class S3ClientConnectionMgr extends BaseClient {
         LOG.debug("==> S3ClientConnectionMgr.connectionTest ServiceName: " + serviceName + "Configs" + configs);
         boolean connectivityStatus = false;
         Map<String, Object> responseData = new HashMap<String, Object>();
-        // String bucketName = "odp-ranger-test";
-        S3Client s3 = getS3client(configs);
         String bucketName = configs.get(RangerS3Constants.BUCKET_NAME);
+
+        S3Client s3;
+        try {
+            s3 = getS3client(configs);
+        } catch (IllegalArgumentException e) {
+            String failureMsg = "Configuration error: " + e.getMessage();
+            generateResponseDataMap(connectivityStatus, failureMsg, failureMsg, null, null, responseData);
+            LOG.error("<== S3ClientConnectionMgr.connectionTest Configuration error: " + e.getMessage(), e);
+            return responseData;
+        }
 
         try {
             // Using ListObjectsV2 approach
@@ -108,6 +116,12 @@ public class S3ClientConnectionMgr extends BaseClient {
         String secretKey = configs.get(RangerS3Constants.SECRET_KEY);
         String endPointOCE = configs.get(RangerS3Constants.ENDPOINT);
         String regionstr = configs.get(RangerS3Constants.REGION);
+
+        validateRequiredConfig(accessKey, RangerS3Constants.ACCESS_KEY, "S3 client");
+        validateRequiredConfig(secretKey, RangerS3Constants.SECRET_KEY, "S3 client");
+        validateRequiredConfig(endPointOCE, RangerS3Constants.ENDPOINT, "S3 client");
+        validateRequiredConfig(regionstr, RangerS3Constants.REGION, "S3 client");
+
         AwsBasicCredentials awsCreds3 = AwsBasicCredentials.create(accessKey, secretKey);
         Region region = Region.of(regionstr);
         return S3Client.builder()
@@ -126,6 +140,14 @@ public class S3ClientConnectionMgr extends BaseClient {
         String regionStr = configs.get(RangerS3Constants.REGION);
         boolean isAwsS3  = awsS3Str == null || Boolean.parseBoolean(awsS3Str);
 
+        validateRequiredConfig(accessKey, RangerS3Constants.ACCESS_KEY, "IAM client");
+        validateRequiredConfig(secretKey, RangerS3Constants.SECRET_KEY, "IAM client");
+
+        if (!isAwsS3) {
+            validateRequiredConfig(endpoint, RangerS3Constants.ENDPOINT,
+                    "IAM client when '" + RangerS3Constants.AWS_S3 + "' is false (non-AWS S3-compatible mode)");
+        }
+
         AwsBasicCredentials awsCreds3 = AwsBasicCredentials.create(accessKey, secretKey);
 
         if (isAwsS3) {
@@ -141,6 +163,13 @@ public class S3ClientConnectionMgr extends BaseClient {
                 .endpointOverride(URI.create(endpoint))
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds3))
                 .build();
+        }
+    }
+
+    private static void validateRequiredConfig(String value, String configName, String context) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Required configuration '" + configName + "' is missing or empty for " + context);
         }
     }
 }

--- a/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
+++ b/s3-agent/src/main/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgr.java
@@ -121,6 +121,7 @@ public class S3ClientConnectionMgr extends BaseClient {
         String secretKey = configs.get(RangerS3Constants.SECRET_KEY);
         String awsS3Str  = configs.get(RangerS3Constants.AWS_S3);
         String endpoint = configs.get(RangerS3Constants.ENDPOINT);
+        String regionStr = configs.get(RangerS3Constants.REGION);
         boolean isAwsS3  = awsS3Str == null || Boolean.parseBoolean(awsS3Str);
 
         AwsBasicCredentials awsCreds3 = AwsBasicCredentials.create(accessKey, secretKey);
@@ -131,8 +132,10 @@ public class S3ClientConnectionMgr extends BaseClient {
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds3))
                 .build();
         } else {
-            // For non-AWS / S3-compatible environments, build IAM client using the endpoint provided in Ranger S3 service configs.
+            // For non-AWS / S3-compatible (e.g. Ceph RGW): use service endpoint for IAM and explicit region (SDK requires region even with endpointOverride)
+            Region region = (regionStr != null && !regionStr.isEmpty()) ? Region.of(regionStr) : Region.US_EAST_1;
             return IamClient.builder()
+                .region(region)
                 .endpointOverride(URI.create(endpoint))
                 .credentialsProvider(StaticCredentialsProvider.create(awsCreds3))
                 .build();

--- a/s3-agent/src/test/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgrTest.java
+++ b/s3-agent/src/test/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgrTest.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ranger.services.s3.client;
+
+import com.adobe.testing.s3mock.junit5.S3MockExtension;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.ListUsersRequest;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for {@link S3ClientConnectionMgr} covering the ODP-6188 changes.
+ *
+ * getIamClient (ODP-6188) — tested via WireMock acting as a stand-in for a
+ * non-AWS IAM endpoint (e.g. Ceph RGW):
+ *      With {@code aws_s3=false} the client must send requests to the custom endpoint
+ *          via {@code endpointOverride(URI.create(endpoint))}.
+ *      Region defaults to {@code us-east-1} when not configured; an explicit region
+ *          overrides the default. Both are verified via the AWS Signature V4
+ *          {@code Authorization} header: {@code Credential=KEY/DATE/<region>/iam/aws4_request}.
+ *
+ * getS3client / connectionTest — tested via S3Mock confirming that
+ * {@code endpointOverride} routes S3 traffic to a custom endpoint and that
+ * {@code connectionTest} correctly reports success/failure.
+ */
+public class S3ClientConnectionMgrTest {
+
+    // ── WireMock (IAM endpoint stub) ──────────────────────────────────────────
+
+    @RegisterExtension
+    static final WireMockExtension WIRE_MOCK = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build();
+
+    // ── S3Mock (S3 endpoint stub) ─────────────────────────────────────────────
+
+    private static final String BUCKET       = "test-bucket";
+    private static final String SERVICE_NAME = "testS3Service";
+
+    @RegisterExtension
+    static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
+
+    @BeforeEach
+    void createBucket(final S3Client s3MockClient) {
+        s3MockClient.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Map<String, String> iamConfigs(String region) {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("accesskey", "test-access-key");
+        configs.put("secretkey", "test-secret-key");
+        configs.put("endpoint",  WIRE_MOCK.baseUrl());
+        configs.put("aws_s3",    "false");
+        if (region != null) {
+            configs.put("region", region);
+        }
+        return configs;
+    }
+
+    private Map<String, String> s3Configs(String bucket) {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("accesskey",  "test-access-key");
+        configs.put("secretkey",  "test-secret-key");
+        configs.put("endpoint",   "http://localhost:" + S3_MOCK.getPort());
+        configs.put("region",     "us-east-1");
+        configs.put("bucketname", bucket);
+        return configs;
+    }
+
+    private void makeIamCall(IamClient client) {
+        try {
+            client.listUsers(ListUsersRequest.builder().build());
+        } catch (Exception ignored) {
+            // WireMock returns an empty 200; SDK may fail to parse it — that is fine.
+            // What matters is that the HTTP request was sent to the stub.
+        }
+    }
+
+    // ── getIamClient: endpoint override ──────────────────────────────────────
+
+    /**
+     * When aws_s3=false, the IamClient must send requests to the configured custom endpoint,
+     * not to the default AWS IAM endpoint (iam.amazonaws.com).
+     * WireMock captures the outbound request — if endpointOverride is working,
+     * WireMock receives exactly one request.
+     */
+    @Test
+    public void getIamClient_awsS3False_requestsRoutedToCustomEndpoint() {
+        WIRE_MOCK.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)));
+
+        IamClient client = S3ClientConnectionMgr.getIamClient(iamConfigs("us-east-1"));
+        makeIamCall(client);
+
+        WIRE_MOCK.verify(1, postRequestedFor(anyUrl()));
+        client.close();
+    }
+
+    /**
+     * When aws_s3=true, the IamClient must use the default AWS IAM endpoint (iam.amazonaws.com)
+     * and must NOT use the custom endpoint even if one is present in the configs.
+     * WireMock must receive zero requests, confirming endpointOverride was not applied.
+     * The IAM call itself will fail (no real AWS connectivity in tests), but that is expected
+     * and intentionally swallowed in makeIamCall().
+     */
+    @Test
+    public void getIamClient_awsS3True_requestsNotRoutedToCustomEndpoint() {
+        Map<String, String> configs = iamConfigs("us-east-1");
+        configs.put("aws_s3", "true");
+
+        IamClient client = S3ClientConnectionMgr.getIamClient(configs);
+        makeIamCall(client);
+
+        WIRE_MOCK.verify(0, postRequestedFor(anyUrl()));
+        client.close();
+    }
+
+    // ── getIamClient: region defaulting ──────────────────────────────────────
+
+    /**
+     * When aws_s3=false and no region is configured, the IamClient must fall back to us-east-1.
+     * The region is verified via the AWS Signature V4 Authorization header, which embeds it as:
+     * Credential=KEY/DATE/{region}/iam/aws4_request
+     */
+    @Test
+    public void getIamClient_awsS3False_regionAbsent_defaultsToUsEast1InRequestSigning() {
+        WIRE_MOCK.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)));
+
+        IamClient client = S3ClientConnectionMgr.getIamClient(iamConfigs(null));
+        makeIamCall(client);
+
+        WIRE_MOCK.verify(postRequestedFor(anyUrl())
+                .withHeader("Authorization", containing("/us-east-1/iam/")));
+        client.close();
+    }
+
+    /**
+     * When aws_s3=false and a region is explicitly configured, that region must be used
+     * in request signing instead of the us-east-1 default.
+     * Verified via the Authorization header, same as the test above.
+     */
+    @Test
+    public void getIamClient_awsS3False_explicitRegion_usedInRequestSigning() {
+        WIRE_MOCK.stubFor(post(anyUrl()).willReturn(aResponse().withStatus(200)));
+
+        IamClient client = S3ClientConnectionMgr.getIamClient(iamConfigs("eu-west-1"));
+        makeIamCall(client);
+
+        WIRE_MOCK.verify(postRequestedFor(anyUrl())
+                .withHeader("Authorization", containing("/eu-west-1/iam/")));
+        client.close();
+    }
+
+    // ── getS3client ───────────────────────────────────────────────────────────
+
+    /**
+     * Verifies that getS3client() builds a working S3 client that can communicate
+     * through a custom endpoint via endpointOverride.
+     * A successful ListObjectsV2 call against S3Mock confirms end-to-end connectivity,
+     * not just that the client object was constructed without error.
+     */
+    @Test
+    public void getS3client_customEndpoint_canListObjectsViaMock() {
+        S3Client s3Client = S3ClientConnectionMgr.getS3client(s3Configs(BUCKET));
+        assertNotNull(s3Client);
+
+        ListObjectsV2Response response = s3Client.listObjectsV2(
+                ListObjectsV2Request.builder().bucket(BUCKET).build());
+        assertNotNull(response);
+
+        s3Client.close();
+    }
+
+    // ── connectionTest ────────────────────────────────────────────────────────
+
+    /**
+     * When the configured bucket exists and is accessible, connectionTest() must return
+     * connectivityStatus=true with a success message containing the bucket name.
+     * The bucket is pre-created in S3Mock via @BeforeEach.
+     */
+    @Test
+    public void connectionTest_existingBucket_returnsSuccess() {
+        Map<String, Object> result = S3ClientConnectionMgr.connectionTest(SERVICE_NAME, s3Configs(BUCKET));
+
+        assertTrue((Boolean) result.get("connectivityStatus"));
+        assertTrue(result.get("message").toString().contains("ConnectionTest Successful"));
+        assertTrue(result.get("message").toString().contains(BUCKET));
+    }
+
+    /**
+     * When the configured bucket does not exist, S3Mock returns NoSuchBucketException.
+     * connectionTest() must catch it and return connectivityStatus=false with a descriptive
+     * failure message, rather than propagating the exception to the caller.
+     */
+    @Test
+    public void connectionTest_nonExistingBucket_returnsFailure() {
+        Map<String, Object> result = S3ClientConnectionMgr.connectionTest(SERVICE_NAME, s3Configs("nonexistent-bucket"));
+
+        assertFalse((Boolean) result.get("connectivityStatus"));
+        assertTrue(result.get("message").toString().contains("does not exist"));
+    }
+}

--- a/s3-agent/src/test/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgrTest.java
+++ b/s3-agent/src/test/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgrTest.java
@@ -39,9 +39,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration tests for {@link S3ClientConnectionMgr} covering the ODP-6188 changes.
@@ -60,6 +58,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class S3ClientConnectionMgrTest {
 
+    // Force the AWS SDK to use a single HTTP implementation when multiple are on the classpath
+    // (e.g. url-connection-client vs apache-client pulled in by s3mock or other test deps).
+    static {
+        System.setProperty("software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+    }
+
     // ── WireMock (IAM endpoint stub) ──────────────────────────────────────────
 
     @RegisterExtension
@@ -71,15 +76,15 @@ public class S3ClientConnectionMgrTest {
 
     private static final String BUCKET       = "test-bucket";
     private static final String SERVICE_NAME = "testS3Service";
+    private static final int PORT = 9090;
 
     @RegisterExtension
-    static final S3MockExtension S3_MOCK = S3MockExtension.builder().silent().build();
+    static final S3MockExtension S3_MOCK = S3MockExtension.builder().withHttpPort(PORT).silent().build();
 
     @BeforeEach
     void createBucket(final S3Client s3MockClient) {
         s3MockClient.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
     }
-
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private Map<String, String> iamConfigs(String region) {
@@ -98,7 +103,7 @@ public class S3ClientConnectionMgrTest {
         Map<String, String> configs = new HashMap<>();
         configs.put("accesskey",  "test-access-key");
         configs.put("secretkey",  "test-secret-key");
-        configs.put("endpoint",   "http://localhost:" + S3_MOCK.getPort());
+        configs.put("endpoint",   "http://localhost:" + PORT);
         configs.put("region",     "us-east-1");
         configs.put("bucketname", bucket);
         return configs;
@@ -197,14 +202,17 @@ public class S3ClientConnectionMgrTest {
      */
     @Test
     public void getS3client_customEndpoint_canListObjectsViaMock() {
-        S3Client s3Client = S3ClientConnectionMgr.getS3client(s3Configs(BUCKET));
-        assertNotNull(s3Client);
-
-        ListObjectsV2Response response = s3Client.listObjectsV2(
-                ListObjectsV2Request.builder().bucket(BUCKET).build());
-        assertNotNull(response);
-
-        s3Client.close();
+        try (S3Client s3ClientUnderTest = S3ClientConnectionMgr.getS3client(s3Configs(BUCKET))) {
+            assertNotNull(s3ClientUnderTest);
+            try {
+                ListObjectsV2Response response = s3ClientUnderTest.listObjectsV2(
+                        ListObjectsV2Request.builder().bucket(BUCKET).build());
+                assertNotNull(response);
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw e;
+            }
+        }
     }
 
     // ── connectionTest ────────────────────────────────────────────────────────

--- a/s3-agent/src/test/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgrTest.java
+++ b/s3-agent/src/test/java/org/apache/ranger/services/s3/client/S3ClientConnectionMgrTest.java
@@ -138,22 +138,53 @@ public class S3ClientConnectionMgrTest {
     }
 
     /**
-     * When aws_s3=true, the IamClient must use the default AWS IAM endpoint (iam.amazonaws.com)
-     * and must NOT use the custom endpoint even if one is present in the configs.
-     * WireMock must receive zero requests, confirming endpointOverride was not applied.
-     * The IAM call itself will fail (no real AWS connectivity in tests), but that is expected
-     * and intentionally swallowed in makeIamCall().
+     * When aws_s3=false but endpoint is missing, getIamClient() must throw
+     * IllegalArgumentException with a descriptive message, not fail later with NPE
+     * or cryptic URI parsing errors.
      */
     @Test
-    public void getIamClient_awsS3True_requestsNotRoutedToCustomEndpoint() {
-        Map<String, String> configs = iamConfigs("us-east-1");
+    public void getIamClient_awsS3False_missingEndpoint_throwsIllegalArgumentException() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("accesskey", "test-access-key");
+        configs.put("secretkey", "test-secret-key");
+        configs.put("aws_s3", "false");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> S3ClientConnectionMgr.getIamClient(configs));
+
+        assertTrue(ex.getMessage().contains("endpoint"));
+        assertTrue(ex.getMessage().contains("aws_s3"));
+    }
+
+    /**
+     * When aws_s3=true, endpoint is not required for IAM client (uses AWS default).
+     * Client creation should succeed even without endpoint configured.
+     */
+    @Test
+    public void getIamClient_awsS3True_missingEndpoint_succeeds() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("accesskey", "test-access-key");
+        configs.put("secretkey", "test-secret-key");
         configs.put("aws_s3", "true");
 
         IamClient client = S3ClientConnectionMgr.getIamClient(configs);
-        makeIamCall(client);
-
-        WIRE_MOCK.verify(0, postRequestedFor(anyUrl()));
+        assertNotNull(client);
         client.close();
+    }
+
+    /**
+     * When accesskey is missing, getIamClient() must throw IllegalArgumentException.
+     */
+    @Test
+    public void getIamClient_missingAccessKey_throwsIllegalArgumentException() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("secretkey", "test-secret-key");
+        configs.put("aws_s3", "true");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> S3ClientConnectionMgr.getIamClient(configs));
+
+        assertTrue(ex.getMessage().contains("accesskey"));
     }
 
     // ── getIamClient: region defaulting ──────────────────────────────────────
@@ -242,5 +273,40 @@ public class S3ClientConnectionMgrTest {
 
         assertFalse((Boolean) result.get("connectivityStatus"));
         assertTrue(result.get("message").toString().contains("does not exist"));
+    }
+
+    // ── Input validation ──────────────────────────────────────────────────────
+
+    /**
+     * When required S3 config (endpoint) is missing, getS3client() must throw
+     * IllegalArgumentException.
+     */
+    @Test
+    public void getS3client_missingEndpoint_throwsIllegalArgumentException() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("accesskey", "test-access-key");
+        configs.put("secretkey", "test-secret-key");
+        configs.put("region", "us-east-1");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> S3ClientConnectionMgr.getS3client(configs));
+
+        assertTrue(ex.getMessage().contains("endpoint"));
+    }
+
+    /**
+     * When connectionTest() receives invalid config, it should return a failure response
+     * with connectivityStatus=false and a descriptive error message, not throw an exception.
+     */
+    @Test
+    public void connectionTest_missingConfig_returnsConfigurationError() {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("accesskey", "test-access-key");
+        configs.put("bucketname", "some-bucket");
+
+        Map<String, Object> result = S3ClientConnectionMgr.connectionTest(SERVICE_NAME, configs);
+
+        assertFalse((Boolean) result.get("connectivityStatus"));
+        assertTrue(result.get("message").toString().contains("Configuration error"));
     }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Jira: https://accelcentral.atlassian.net/browse/ODP-6188
- Updated Ranger S3 plugin to be able to direct a custom endpoint

### Test cases added
- **Added modules - WireMock/S3Mock**
- WireMock: A mock API server to act as an IAM endpoint. Captures outbound HTTP requests so tests can assert where the SDK sent the request.
- S3Mock: A mock S3 server running locally on a configured port. Create buckets and make real S3 API calls (ListObjectsV2, etc.) against a local stub.

- **Test cases**
     - IAM Client Test (Using WireMock API server)
          1. Endpoint overwrite test when aws_s3=false
          2. Endpoint overwrite test when aws_s3=true
          3. Default region test when aws_s3=false
          4. Region overwrite test when aws_s3=false
     - S3 Connection Test (Using S3Mockup server)
          5. List connection via custom endpoint test against mockup s3 server
          6. List connections by checking the existing test bucket
          7. List connections by checking the non-existing test bucket

## How was this patch tested?
Locally tested

```bash
[root@ceph-3363101 s3-agent]# mvn test -Dtest=S3ClientConnectionMgrTest
[INFO] Scanning for projects...
[INFO]
[INFO] ---------------------< org.apache.ranger:s3-agent >---------------------
[INFO] Building S3 Policies Agent 2.5.0.3.3.6.3-101
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- enforcer:1.4.1:enforce (enforce-maven-version) @ s3-agent ---
[INFO]
[INFO] --- enforcer:1.4.1:enforce (enforce-versions) @ s3-agent ---
[INFO]
[INFO] --- jacoco:0.8.7:prepare-agent (jacoco-initialize) @ s3-agent ---
[INFO] argLine set to -javaagent:/root/.m2/repository/org/jacoco/org.jacoco.agent/0.8.7/org.jacoco.agent-0.8.7-runtime.jar=destfile=/root/ranger/s3-agent/target/jacoco.exec
[INFO]
[INFO] --- remote-resources:1.5:process (process-resource-bundles) @ s3-agent ---
[INFO]
[INFO] --- resources:2.7:resources (default-resources) @ s3-agent ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ranger/s3-agent/src/main/resources
[INFO] Copying 3 resources
[INFO]
[INFO] --- antrun:1.7:run (default) @ s3-agent ---
[INFO] Executing tasks

main:
[INFO] Executed tasks
[INFO]
[INFO] --- compiler:3.3:compile (default-compile) @ s3-agent ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- resources:2.7:testResources (default-testResources) @ s3-agent ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ranger/s3-agent/src/test/resources
[INFO] Copying 3 resources
[INFO]
[INFO] --- compiler:3.3:testCompile (default-testCompile) @ s3-agent ---
[INFO] Compiling 1 source file to /root/ranger/s3-agent/target/test-classes
[WARNING] Unable to autodetect 'javac' path, using 'javac' from the environment.
[INFO]
[INFO] --- surefire:3.0.0-M6:test (default-test) @ s3-agent ---
[WARNING]  Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.ranger.services.s3.client.S3ClientConnectionMgrTest
2026-04-01 23:27:35.490  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:36.498  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.262  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.456  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.496  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.524  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.560  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.617 ERROR 365593 --- [           main] o.a.r.s.s3.client.S3ClientConnectionMgr  : <== S3ClientConnectionMgr.testConnection Error: The specified bucket does not exist. (Service: S3, Status Code: 404, Request ID: , Extended Request ID: null)

software.amazon.awssdk.services.s3.model.NoSuchBucketException: The specified bucket does not exist. (Service: S3, Status Code: 404, Request ID: , Extended Request ID: null)
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleErrorResponse(AwsXmlPredicatedResponseHandler.java:156) ~[aws-xml-protocol-2.17.102.jar:na]
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handleResponse(AwsXmlPredicatedResponseHandler.java:106) ~[aws-xml-protocol-2.17.102.jar:na]
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:84) ~[aws-xml-protocol-2.17.102.jar:na]
	at software.amazon.awssdk.protocols.xml.internal.unmarshall.AwsXmlPredicatedResponseHandler.handle(AwsXmlPredicatedResponseHandler.java:42) ~[aws-xml-protocol-2.17.102.jar:na]
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler$Crc32ValidationResponseHandler.handle(AwsSyncClientHandler.java:95) ~[aws-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.handler.BaseClientHandler.lambda$successTransformationResponseHandler$6(BaseClientHandler.java:234) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:40) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.HandleResponseStage.execute(HandleResponseStage.java:30) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:73) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptTimeoutTrackingStage.execute(ApiCallAttemptTimeoutTrackingStage.java:42) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:78) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.TimeoutExceptionHandlingStage.execute(TimeoutExceptionHandlingStage.java:40) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:50) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallAttemptMetricCollectionStage.execute(ApiCallAttemptMetricCollectionStage.java:36) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:81) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.RetryableStage.execute(RetryableStage.java:36) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:56) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.StreamManagingStage.execute(StreamManagingStage.java:36) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.executeWithTimer(ApiCallTimeoutTrackingStage.java:80) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:60) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallTimeoutTrackingStage.execute(ApiCallTimeoutTrackingStage.java:42) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:48) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ApiCallMetricCollectionStage.execute(ApiCallMetricCollectionStage.java:31) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.RequestPipelineBuilder$ComposingRequestPipelineStage.execute(RequestPipelineBuilder.java:206) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:37) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.pipeline.stages.ExecutionFailureExceptionReportingStage.execute(ExecutionFailureExceptionReportingStage.java:26) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.http.AmazonSyncHttpClient$RequestExecutionBuilderImpl.execute(AmazonSyncHttpClient.java:193) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.invoke(BaseSyncClientHandler.java:103) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.doExecute(BaseSyncClientHandler.java:167) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.lambda$execute$1(BaseSyncClientHandler.java:82) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.measureApiCallSuccess(BaseSyncClientHandler.java:175) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.internal.handler.BaseSyncClientHandler.execute(BaseSyncClientHandler.java:76) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.core.client.handler.SdkSyncClientHandler.execute(SdkSyncClientHandler.java:45) ~[sdk-core-2.17.102.jar:na]
	at software.amazon.awssdk.awscore.client.handler.AwsSyncClientHandler.execute(AwsSyncClientHandler.java:56) ~[aws-core-2.17.102.jar:na]
	at software.amazon.awssdk.services.s3.DefaultS3Client.listObjectsV2(DefaultS3Client.java:6149) ~[s3-2.17.102.jar:na]
	at org.apache.ranger.services.s3.client.S3ClientConnectionMgr.connectionTest(S3ClientConnectionMgr.java:66) ~[classes/:na]
	at org.apache.ranger.services.s3.client.S3ClientConnectionMgrTest.connectionTest_nonExistingBucket_returnsFailure(S3ClientConnectionMgrTest.java:272) ~[test-classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728) ~[junit-platform-commons-1.10.0.jar:1.10.0]
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:139) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]

2026-04-01 23:27:37.622  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.655  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.681  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.702  WARN 365593 --- [           main] s.a.a.h.u.UrlConnectionHttpClient        : SSL Certificate verification is disabled. This is not a safe setting and should only be used for testing.
2026-04-01 23:27:37.724 ERROR 365593 --- [           main] o.a.r.s.s3.client.S3ClientConnectionMgr  : <== S3ClientConnectionMgr.connectionTest Configuration error: Required configuration 'secretkey' is missing or empty for S3 client

java.lang.IllegalArgumentException: Required configuration 'secretkey' is missing or empty for S3 client
	at org.apache.ranger.services.s3.client.S3ClientConnectionMgr.validateRequiredConfig(S3ClientConnectionMgr.java:171) ~[classes/:na]
	at org.apache.ranger.services.s3.client.S3ClientConnectionMgr.getS3client(S3ClientConnectionMgr.java:121) ~[classes/:na]
	at org.apache.ranger.services.s3.client.S3ClientConnectionMgr.connectionTest(S3ClientConnectionMgr.java:52) ~[classes/:na]
	at org.apache.ranger.services.s3.client.S3ClientConnectionMgrTest.connectionTest_missingConfig_returnsConfigurationError(S3ClientConnectionMgrTest.java:307) ~[test-classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:728) ~[junit-platform-commons-1.10.0.jar:1.10.0]
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:218) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:214) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:139) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:69) ~[junit-jupiter-engine-5.10.0.jar:5.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541) ~[na:na]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54) ~[junit-platform-engine-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:198) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:169) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:93) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:58) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:141) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:57) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:103) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:85) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:47) ~[junit-platform-launcher-1.10.0.jar:1.10.0]
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:55) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:223) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:175) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:139) ~[surefire-junit-platform-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:456) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:169) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:595) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:581) ~[surefire-booter-3.0.0-M6.jar:3.0.0-M6]

[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.588 s - in org.apache.ranger.services.s3.client.S3ClientConnectionMgrTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.872 s
[INFO] Finished at: 2026-04-01T23:27:38+05:30
[INFO] ------------------------------------------------------------------------
[root@ceph-3363101 s3-agent]#
```