### PR TITLE
OSV 12863|OSV-12847|OSV-12840|OSV-12841|OSV-12830 Fix CVEs

### DIFF
--- a/distro/src/main/assembly/plugin-yarn.xml
+++ b/distro/src/main/assembly/plugin-yarn.xml
@@ -63,13 +63,13 @@
           <include>com.kstruct:gethostname4j:jar:${kstruct.gethostname4j.version}</include>
           <include>net.java.dev.jna:jna:jar:${jna.version}</include>
           <include>net.java.dev.jna:jna-platform:jar:${jna-platform.version}</include>
-          <include>org.elasticsearch:elasticsearch</include>
+          <!--include>org.elasticsearch:elasticsearch</include>
           <include>org.elasticsearch:elasticsearch-core</include>
           <include>org.elasticsearch:elasticsearch-x-content</include>
           <include>org.elasticsearch.client:elasticsearch-rest-client</include>
           <include>org.elasticsearch.client:elasticsearch-rest-high-level-client</include>
           <include>org.elasticsearch.plugin:rank-eval-client</include>
-          <include>org.elasticsearch.plugin:lang-mustache-client</include>
+          <include>org.elasticsearch.plugin:lang-mustache-client</include-->
           <include>org.apache.httpcomponents:httpcore-nio:jar:${httpcomponents.httpcore.version}</include>
           <include>org.apache.httpcomponents:httpasyncclient:jar:${httpcomponents.httpasyncclient.version}</include>
           <include>org.apache.lucene:lucene-core</include>

--- a/plugin-solr/pom.xml
+++ b/plugin-solr/pom.xml
@@ -111,6 +111,10 @@
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper-jute</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.http2</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compress.version>1.27.1</commons.compress.version>
         <commons.configuration1.version>1.10</commons.configuration1.version>
-        <commons.configuration.version>2.8.0</commons.configuration.version>
+        <commons.configuration.version>2.10.1</commons.configuration.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.digester.version>2.1</commons.digester.version>
         <commons.io.version>2.17.0</commons.io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <derby.version>10.17.1.0</derby.version>
         <dnsjava.version>3.6.2</dnsjava.version>
         <eclipse.jpa.version>2.7.12</eclipse.jpa.version>
-        <elasticsearch.version>7.17.26</elasticsearch.version>
+        <elasticsearch.version>7.17.29</elasticsearch.version>
         <enunciate.version>2.13.2</enunciate.version>
         <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <mockito.version>3.0.0</mockito.version>
         <mockito.all.version>1.10.19</mockito.all.version>
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
-        <netty-all.version>4.1.119.Final</netty-all.version>
+        <netty-all.version>4.1.130.Final</netty-all.version>
         <noggit.version>0.8</noggit.version>
         <orc.core.version>1.6.7</orc.core.version>
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <sqoop.version>1.4.8.3.3.6.4-1</sqoop.version>
         <storm.version>1.2.4</storm.version>
         <sun-jersey-bundle.version>1.19</sun-jersey-bundle.version>
-        <tomcat.embed.version>9.0.105</tomcat.embed.version>
+        <tomcat.embed.version>9.0.115</tomcat.embed.version>
         <testng.version>7.5.1</testng.version>
         <velocity.version>2.4.1</velocity.version>
         <zookeeper.version>3.8.4.3.3.6.4-1</zookeeper.version>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -423,6 +423,10 @@
                    <groupId>org.xerial.snappy</groupId>
                    <artifactId>snappy-java</artifactId>
                </exclusion>
+               <exclusion>
+                   <groupId>org.eclipse.jetty.http2</groupId>
+                   <artifactId>*</artifactId>
+               </exclusion>
           </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
OSV-12830 Drop unused jetty http component jars to address CVEs
OSV-12841 Drop unused elasticsearch jars from yarn plugin packaging to solve CVEs
OSV-12840 Upgrade commons-configuration2 to 2.10.1 to address CVE-2024-29131
OSV-12847 Upgrade Netty to 4.1.130.Final to resolve CVEs
OSV-12863 Upgrade tomcat to 9.0.115 to resolve CVEs