### PR TITLE
OSV-11137|ODP-6332 Drop unused jetty http component jars and upgrade Netty to 4.1.132

### DIFF
--- a/plugin-solr/pom.xml
+++ b/plugin-solr/pom.xml
@@ -111,6 +111,10 @@
                     <groupId>org.apache.zookeeper</groupId>
                     <artifactId>zookeeper-jute</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.http2</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <mockito.version>3.0.0</mockito.version>
         <mockito.all.version>1.10.19</mockito.all.version>
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
-        <netty-all.version>4.1.130.Final</netty-all.version>
+        <netty-all.version>4.1.132.Final</netty-all.version>
         <noggit.version>0.8</noggit.version>
         <orc.core.version>1.6.7</orc.core.version>
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -424,6 +424,10 @@
                    <groupId>org.xerial.snappy</groupId>
                    <artifactId>snappy-java</artifactId>
                </exclusion>
+               <exclusion>
+                   <groupId>org.eclipse.jetty.http2</groupId>
+                   <artifactId>*</artifactId>
+               </exclusion>
           </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
OSV-11137 Drop unused jetty http component jars to address CVEs
ODP-6332 Upgrade Netty to 4.1.132.Final