### PR TITLE
ODP-6314: Make ozone.om.service.ids optional for Ranger Ozone connection to support non-ha OM

### DIFF
--- a/plugin-ozone/src/main/java/org/apache/ranger/services/ozone/client/OzoneClient.java
+++ b/plugin-ozone/src/main/java/org/apache/ranger/services/ozone/client/OzoneClient.java
@@ -54,8 +54,12 @@ public class OzoneClient extends BaseClient {
             }
         }
         Subject.doAs(getLoginSubject(), (PrivilegedExceptionAction<Void>) () -> {
-            String[] serviceIds = conf.getTrimmedStrings("ozone.om.service.ids", "ozone1");
-            ozoneClient = OzoneClientFactory.getRpcClient(serviceIds[0], conf);
+            String[] serviceIds = conf.getTrimmedStrings("ozone.om.service.ids");
+            if (serviceIds != null && serviceIds.length > 0 && serviceIds[0] != null && !serviceIds[0].isEmpty()) {
+                ozoneClient = OzoneClientFactory.getRpcClient(serviceIds[0], conf);
+            } else {
+                ozoneClient = OzoneClientFactory.getRpcClient(conf);
+            }
             return null;
         });
     }


### PR DESCRIPTION
ODP-6314: Make ozone.om.service.ids optional for Ranger Ozone connection to support non-ha OM
