### PR TITLE
ODP-6543: Enable Ranger Atlas plugin

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -60,6 +60,7 @@
                                         <descriptor>src/main/assembly/plugin-yarn.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-ozone.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-solr.xml</descriptor>
+                                        <descriptor>src/main/assembly/plugin-atlas.xml</descriptor>
                                         <descriptor>src/main/assembly/admin-web.xml</descriptor>
                                         <descriptor>src/main/assembly/solr_audit_conf.xml</descriptor>
                                         <descriptor>src/main/assembly/usersync.xml</descriptor>
@@ -495,6 +496,7 @@
                                         <descriptor>src/main/assembly/plugin-yarn.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-ozone.xml</descriptor>
                                         <descriptor>src/main/assembly/plugin-solr.xml</descriptor>
+                                        <descriptor>src/main/assembly/plugin-atlas.xml</descriptor>
                                         <descriptor>src/main/assembly/admin-web.xml</descriptor>
                                         <descriptor>src/main/assembly/solr_audit_conf.xml</descriptor>
                                         <descriptor>src/main/assembly/usersync.xml</descriptor>
@@ -623,6 +625,18 @@
         <dependency>
             <groupId>org.apache.ranger</groupId>
             <artifactId>ranger-solr-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-atlas-plugin-shim</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ranger</groupId>
+            <artifactId>ranger-atlas-plugin</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,7 @@
                 <module>security-admin</module>
                 <module>plugin-kafka</module>
                 <module>plugin-solr</module>
+                <module>plugin-atlas</module>
                 <module>plugin-nifi</module>
                 <module>plugin-nifi-registry</module>
                 <module>ugsync-util</module>
@@ -312,6 +313,7 @@
                 <module>ranger-ozone-plugin-shim</module>
                 <module>ranger-kafka-plugin-shim</module>
                 <module>ranger-solr-plugin-shim</module>
+                <module>ranger-atlas-plugin-shim</module>
                 <module>ranger-kms-plugin-shim</module>
                 <module>ranger-examples</module>
                 <module>ranger-tools</module>
@@ -491,6 +493,8 @@
                 <module>credentialbuilder</module>
                 <module>ranger-plugin-classloader</module>
                 <module>ranger-util</module>
+                <module>plugin-atlas</module>
+                <module>ranger-atlas-plugin-shim</module>
             </modules>
         </profile>
         <profile>
@@ -594,6 +598,7 @@
                 <module>security-admin</module>
                 <module>plugin-kafka</module>
                 <module>plugin-solr</module>
+                <module>plugin-atlas</module>
                 <module>plugin-nifi</module>
                 <module>plugin-nifi-registry</module>
                 <module>ugsync-util</module>
@@ -614,6 +619,7 @@
                 <module>ranger-ozone-plugin-shim</module>
                 <module>ranger-kafka-plugin-shim</module>
                 <module>ranger-solr-plugin-shim</module>
+                <module>ranger-atlas-plugin-shim</module>
                 <module>ranger-kms-plugin-shim</module>
                 <module>ranger-examples</module>
                 <module>ranger-tools</module>
@@ -670,6 +676,7 @@
                 <module>security-admin</module>
                 <module>plugin-kafka</module>
                 <module>plugin-solr</module>
+                <module>plugin-atlas</module>
                 <module>plugin-nifi</module>
                 <module>plugin-nifi-registry</module>
                 <module>ugsync-util</module>
@@ -689,6 +696,7 @@
                 <module>ranger-ozone-plugin-shim</module>
                 <module>ranger-kafka-plugin-shim</module>
                 <module>ranger-solr-plugin-shim</module>
+                <module>ranger-atlas-plugin-shim</module>
                 <module>ranger-kms-plugin-shim</module>
                 <module>ranger-examples</module>
                 <module>ranger-tools</module>


### PR DESCRIPTION
- pom.xml: add plugin-atlas and ranger-atlas-plugin-shim to all full-build profiles (all, linux, rpm); fix ranger-atlas-plugin profile which was missing the actual plugin modules
- distro/pom.xml: add plugin-atlas.xml assembly descriptor to default and linux profiles; add ranger-atlas-plugin-shim and ranger-atlas-plugin as provided dependencies so the assembly picks up the JARs

The plugin-atlas module and assembly descriptor already existed but were never wired into the build. No code changes to the plugin itself.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
