### PR TITLE
ODP-6734 Handle Hive 4 insert_only ACID tables in HMS Thrift wrapper

### DIFF
--- a/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
@@ -390,15 +390,14 @@ public class HMSClientWrapper implements AutoCloseable {
 
     public TableInfo getTable(String dbName, String tableName) throws Exception {
         ensureConnected();
-        Method method = thriftClient.getClass().getMethod("get_table", String.class, String.class);
-        Object table = method.invoke(thriftClient, dbName, tableName);
 
+        Object table = fetchTable(dbName, tableName);
         if (table == null) {
             return null;
         }
 
         TableInfo info = new TableInfo();
-        info.dbName = (String) table.getClass().getMethod("getDbName").invoke(table);
+        info.dbName    = (String) table.getClass().getMethod("getDbName").invoke(table);
         info.tableName = (String) table.getClass().getMethod("getTableName").invoke(table);
         info.tableType = (String) table.getClass().getMethod("getTableType").invoke(table);
 
@@ -408,6 +407,57 @@ public class HMSClientWrapper implements AutoCloseable {
         }
 
         return info;
+    }
+
+    /**
+     * Fetch a Table via the newest available HMS Thrift signature.
+     *
+     * Hive 4 HMS filters out tables whose {@code transactional_properties=insert_only}
+     * (and full-ACID) unless the caller declares
+     * {@link org.apache.hadoop.hive.metastore.api.ClientCapability#INSERT_ONLY_TABLES}.
+     * The legacy two-arg {@code get_table(String, String)} has no way to pass
+     * capabilities, so on Hive 4 it server-side NPEs for those tables and surfaces
+     * client-side as an {@link java.lang.reflect.InvocationTargetException} with a
+     * null message.
+     *
+     * Strategy (mirrors {@code wrapWithSASL} 7-arg-vs-6-arg drift tolerance):
+     *   1. Try {@code get_table_req(GetTableRequest)} (Hive 3.0+) with
+     *      {@code ClientCapabilities([INSERT_ONLY_TABLES])} so ACID v2 tables are
+     *      returned. Unwrap {@code GetTableResult.getTable()}.
+     *   2. Fall back to legacy {@code get_table(String, String)} on older HMS that
+     *      doesn't expose the v2 signature.
+     */
+    private Object fetchTable(String dbName, String tableName) throws Exception {
+        try {
+            Class<?> reqClass  = Class.forName("org.apache.hadoop.hive.metastore.api.GetTableRequest");
+            Class<?> capsClass = Class.forName("org.apache.hadoop.hive.metastore.api.ClientCapabilities");
+            Class<?> capClass  = Class.forName("org.apache.hadoop.hive.metastore.api.ClientCapability");
+
+            // ClientCapabilities(List<ClientCapability>) with INSERT_ONLY_TABLES.
+            Object insertOnlyCap = capClass.getMethod("valueOf", String.class).invoke(null, "INSERT_ONLY_TABLES");
+            java.util.List<Object> capList = new java.util.ArrayList<>();
+            capList.add(insertOnlyCap);
+            Object caps = capsClass.getConstructor(java.util.List.class).newInstance(capList);
+
+            // GetTableRequest(dbName, tblName) + setCapabilities(...).
+            Object req = reqClass.getConstructor(String.class, String.class).newInstance(dbName, tableName);
+            reqClass.getMethod("setCapabilities", capsClass).invoke(req, caps);
+
+            Method getTableReq = thriftClient.getClass().getMethod("get_table_req", reqClass);
+            Object resp = getTableReq.invoke(thriftClient, req);
+
+            if (resp == null) {
+                return null;
+            }
+            return resp.getClass().getMethod("getTable").invoke(resp);
+        } catch (ClassNotFoundException | NoSuchMethodException olderHms) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("get_table_req not available on this HMS; falling back to legacy get_table: {}",
+                          olderHms.toString());
+            }
+            Method legacy = thriftClient.getClass().getMethod("get_table", String.class, String.class);
+            return legacy.invoke(thriftClient, dbName, tableName);
+        }
     }
 
     public long getCurrentNotificationEventId() throws Exception {

--- a/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
@@ -443,12 +443,18 @@ public class RangerRMSPollerService {
                             }
                         } catch (Exception e) {
                             stats.failed++;
-                            LOG.warn("Error processing table {}.{}: {}", dbName, tableName, e.getMessage());
+                            Throwable rootCause = e;
+                            while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+                                rootCause = rootCause.getCause();
+                            }
+                            LOG.warn("Error processing table {}.{}: [{}] {}",
+                                    dbName, tableName, rootCause.getClass().getName(), rootCause.getMessage(), e);
                         }
                     }
 
                 } catch (Exception e) {
-                    LOG.warn("Error processing database {}: {}", dbName, e.getMessage());
+                    LOG.warn("Error processing database {}: [{}] {}",
+                            dbName, e.getClass().getName(), e.getMessage(), e);
                 }
             }
 


### PR DESCRIPTION
The reflection-based HMSClientWrapper.getTable used the legacy get_table(String, String) Thrift signature, which has no way to declare ClientCapabilities. Hive 4 HMS filters out tables with transactional_properties=insert_only (and full-ACID) unless the caller declares ClientCapability.INSERT_ONLY_TABLES, so the v1 call NPEs server-side and surfaces client-side as an InvocationTargetException with a null message.

Net effect on ODP 3.3.6.3-103 + Hive 4.0.1: every managed insert_only table (the default for new tables in Hive 4) was silently dropped from the RMS mapping set. Affected tables -- including partitioned and bucketed variants -- never get their HDFS paths mapped, so chained Hive policies never apply to those paths. No operator-visible error beyond a single WARN per dropped table per full-sync cycle.

Switch HMSClientWrapper.fetchTable() to get_table_req(GetTableRequest) with ClientCapabilities([INSERT_ONLY_TABLES]) and fall back to the legacy two-arg signature via NoSuchMethodException / ClassNotFoundException for older HMS. Mirrors the
TSaslClientTransport 6-vs-7-arg ctor drift tolerance from e1e4fa58.

Also tighten the table-processing catch blocks in
RangerRMSPollerService.performFullSync to log the root cause class
+ message + full stack instead of just e.getMessage(). The previous "Error processing table <db>.<tbl>: null" was uninformative; future signature-drift failures now surface their cause directly.

Doc updates: user-guide §7.3d replaces the placeholder "enable DEBUG and see what happens" with the confirmed insert_only / v1-vs-v2 diagnosis and resolution. Developer-guide §9 tracks the two known Thrift signature drifts the wrapper now handles, with HMSClientWrapper.fetchTable called out as the reference "try-newest-fall-back-to-prior" implementation.

Validated on ODP 3.3.6.3-103 against Hive 4.0.1 with a 30-table HMS: attempted=30, failed=0 (vs failed=10 pre-fix); last_known_version advanced 18 -> 28; all 10 previously-dropped insert_only tables present in x_rms_resource_mapping including partitioned (instagram.instagrampartitionedexample) and bucketed (instagram.bucketingexample, twitter.bucketingexample).

Files changed:
  security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
  security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
