### PR TITLE
ODP-6735 Persist cumulative RMS mapping cache to on-disk policycache …

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerRMSChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerRMSChainedPlugin.java
@@ -384,6 +384,18 @@ public abstract class RangerRMSChainedPlugin extends RangerChainedPlugin {
     }
 
     /**
+     * Accessor for the underlying mapping cache. Used by
+     * {@link org.apache.ranger.plugin.util.RangerRMSMappingRefresher} to
+     * snapshot the cumulative cache state into a {@link ServiceRMSMappings}
+     * before persisting to the on-disk policycache JSON, so a delta payload
+     * doesn't overwrite the cumulative state on disk and cause data loss
+     * across plugin restarts.
+     */
+    public RangerRMSMappingCache getMappingCache() {
+        return mappingCache;
+    }
+
+    /**
      * Extract storage path from the request. Override in subclasses for specific resource types.
      */
     protected abstract String extractStoragePath(RangerAccessRequest request);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingCache.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingCache.java
@@ -440,6 +440,50 @@ public class RangerRMSMappingCache {
     }
 
     /**
+     * Snapshot the current in-memory cache state as a {@link ServiceRMSMappings}
+     * suitable for persisting to the on-disk policycache JSON.
+     *
+     * Why this exists: the plugin-side refresher persists the wire payload it
+     * just received -- but that payload may be a delta that contains only the
+     * newly-added mappings. Writing the raw delta to disk loses cumulative
+     * state, so a NameNode restart that then reads the cache JSON would see
+     * only the most recent delta's worth of mappings (correct mappingVersion,
+     * but a sparse resourceMappings list) and `lastKnownVersion` would already
+     * equal the server's current version -- meaning the plugin would never
+     * re-download the full set until a watermark fallback forces it.
+     *
+     * Persisting the cumulative snapshot built here keeps load-from-cache
+     * restart-safe and consistent with the developer-guide §3 lifecycle
+     * contract ("Plugin restart: policycache JSON on disk survives").
+     */
+    public ServiceRMSMappings toServiceRMSMappings() {
+        CacheSnapshot snap = snapshot.get();
+        if (snap == null) {
+            return null;
+        }
+
+        ServiceRMSMappings ret = new ServiceRMSMappings(serviceName, hlServiceName, mappingVersion);
+        ret.setIsDelta(false);
+        ret.setLastKnownVersion(mappingVersion);
+
+        if (snap.resourcesByGuid != null && !snap.resourcesByGuid.isEmpty()) {
+            ret.setServiceResources(new HashMap<>(snap.resourcesByGuid));
+        }
+
+        if (snap.mappingsByHlResource != null && !snap.mappingsByHlResource.isEmpty()) {
+            List<RMSResourceMapping> mappings = new ArrayList<>(snap.mappingsByHlResource.size());
+            for (MappingEntry entry : snap.mappingsByHlResource.values()) {
+                if (entry != null && entry.getMapping() != null) {
+                    mappings.add(entry.getMapping());
+                }
+            }
+            ret.setResourceMappings(mappings);
+        }
+
+        return ret;
+    }
+
+    /**
      * Mapping entry containing both HL and LL resources.
      */
     public static class MappingEntry {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
@@ -193,7 +193,21 @@ public class RangerRMSMappingRefresher implements Runnable {
                              serviceName, lastKnownVersion, newVersion, mappings.getIsDelta());
 
                     chainedPlugin.updateMappings(mappings);
-                    saveToCache(mappings);
+
+                    // Persist the cumulative cache state, not the raw wire payload.
+                    // The payload may be a delta (only newly-added mappings); writing
+                    // it directly would cause a NameNode restart to load only those
+                    // delta-shaped mappings -- with lastKnownVersion already equal
+                    // to the server's currentVersion, the server would then return
+                    // 304 / no-change and the plugin would permanently miss the
+                    // cumulative state until a watermark fallback forced a full
+                    // re-download. Snapshot from the cache instead so the on-disk
+                    // file is always a complete picture of what's authoritative
+                    // for this service.
+                    ServiceRMSMappings snapshot = chainedPlugin.getMappingCache() != null
+                            ? chainedPlugin.getMappingCache().toServiceRMSMappings()
+                            : null;
+                    saveToCache(snapshot != null ? snapshot : mappings);
 
                     this.lastKnownVersion = newVersion;
                 } else {


### PR DESCRIPTION
…JSON

RangerRMSMappingRefresher.downloadMappings previously called saveToCache(mappings) where `mappings` was the raw wire payload just received from Ranger Admin. When the server returned a delta response (isDelta=true), the on-disk policycache JSON was overwritten with the sparse delta -- not the cumulative in-memory cache state.

On NameNode restart, loadFromCache() reads the sparse JSON and dispatches to applyDelta (because isDelta=true on the saved file), merging just the delta on top of an empty cache. lastKnownVersion is set to the server's current version, the next poll returns 304 / no-change, and the plugin permanently authorizes on a partial mapping set until a watermark fallback forces a full re-download. HA failover triggers the same bug on the new active.

Add RangerRMSMappingCache.toServiceRMSMappings() returning the cumulative cache state as a ServiceRMSMappings with isDelta=false (enumerating snapshot.mappingsByHlResource.values() for the mapping list, snapshot.resourcesByGuid for the resource map). Expose RangerRMSChainedPlugin.getMappingCache() so the refresher can reach it. saveToCache now persists the cumulative snapshot regardless of whether the most recent wire payload was full or delta. Restores the developer-guide §3 lifecycle contract that the on-disk JSON is a complete restart-loadable snapshot.

Doc updates: user-guide §7.4a captures the symptom fingerprint (mappingVersion >> resourceMappings.length, isDelta=true on disk), the recovery for older builds, and -- learned the hard way during this fix -- a hot-patch verification gotcha: full-payload tests can't distinguish patched-vs-unpatched code (both write the same on-disk file when isDelta=false), only a delta test can. Plus the Ranger plugin classloader directory trap (it loads every file in ranger-hdfs-plugin-impl/, not just *.jar, so backup siblings like *.jar.bak.* shadow the live JAR -- always park backups outside the plugin-impl directory). Developer-guide §3 lifecycle table now states the cumulative-snapshot contract explicitly.

Validated on ODP 3.3.6.3-103, 34-mapping cluster:
- Pre-fix: after delta v33 -> v34, JSON had mappingVersion=34, isDelta=true, resourceMappings.length=1.
- Post-fix: JSON has mappingVersion=34, isDelta=false, resourceMappings.length=34.
- NN restart loads cumulative state correctly: RangerRMSMappingCache full update: resourceCount=68, mappingCount=34.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
