### PR TITLE
ODP-6977: Enable Ranger kafka4 plugin

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-kafka.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-kafka.json
@@ -213,7 +213,7 @@
 			"itemId":3,
 			"name":"zookeeper.connect",
 			"type":"string",
-			"mandatory":true,
+			"mandatory":false,
 			"defaultValue":"localhost:2181",
 			"label":"Zookeeper Connect String"
 		},

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -62,6 +62,7 @@
 					<include>com.sun.jersey:jersey-bundle</include>
 					<include>commons-logging:commons-logging</include>
 					<include>commons-lang:commons-lang</include>
+					<include>org.apache.commons:commons-lang3</include>
 					<include>commons-io:commons-io</include>
 					<include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
 					<include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>

--- a/distro/src/main/assembly/plugin-kafka.xml
+++ b/distro/src/main/assembly/plugin-kafka.xml
@@ -63,6 +63,7 @@
 					<include>commons-logging:commons-logging</include>
 					<include>commons-lang:commons-lang</include>
 					<include>org.apache.commons:commons-lang3</include>
+					<include>org.apache.commons:commons-compress</include>
 					<include>commons-io:commons-io</include>
 					<include>org.apache.httpcomponents:httpclient:jar:${httpcomponents.httpclient.version}</include>
 					<include>org.apache.httpcomponents:httpcore:jar:${httpcomponents.httpcore.version}</include>

--- a/plugin-kafka/conf/kafka4-ranger-env.sh
+++ b/plugin-kafka/conf/kafka4-ranger-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+classpathmunge () {
+        escaped=`echo $1 | sed -e 's:\*:\\\\*:g'`
+        if ! echo ${CLASSPATH} | /bin/egrep -q "(^|:)${escaped}($|:)" ; then
+           if [ "$2" = "before" ] ; then
+              CLASSPATH=$1:${CLASSPATH}
+           else
+              CLASSPATH=${CLASSPATH}:$1
+           fi
+        fi
+}
+classpathmunge /etc/kafka4/conf
+classpathmunge '/usr/odp/current/hadoop-hdfs-client/*'
+classpathmunge '/usr/odp/current/hadoop-hdfs-client/lib/*'
+classpathmunge '/etc/hadoop/conf'
+export CLASSPATH
+unset classpathmunge


### PR DESCRIPTION
- Added Kafka4-specific Ranger environment configurations required for compatibility.
- Fixed Ranger repository creation for Kafka4 service definitions.
- Resolved Kafka4 Ranger plugin startup issues during service initialization.
- Updated plugin configuration handling to align with Kafka4 deployment requirements.