### PR TITLE
ODP-7044 Match opentelemetry version to HBase to fix CNF in HBase plugin

### DIFF
--- a/distro/src/main/assembly/admin-web.xml
+++ b/distro/src/main/assembly/admin-web.xml
@@ -108,7 +108,7 @@
             <include>org.apache.hbase.thirdparty:hbase-shaded-miscellaneous:jar:${hbase-shaded-miscellaneous}</include>
             <include>io.opentelemetry:opentelemetry-api:jar:${io.opentelemetry.version}</include>
             <include>io.opentelemetry:opentelemetry-context:jar:${io.opentelemetry.version}</include>
-            <include>io.opentelemetry:opentelemetry-semconv:jar:${io.opentelemetry-semconv.version}</include>
+            <include>io.opentelemetry.semconv:opentelemetry-semconv:jar:${io.opentelemetry-semconv.version}</include>
             <include>io.dropwizard.metrics:metrics-core</include>
             <include>org.apache.commons:commons-compress:jar:${commons.compress.version}</include>
             <include>org.apache.commons:commons-lang3:jar:${commons.lang3.version}</include>

--- a/hbase-agent/pom.xml
+++ b/hbase-agent/pom.xml
@@ -226,7 +226,7 @@
             <version>${io.opentelemetry.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.opentelemetry</groupId>
+            <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
             <version>${io.opentelemetry-semconv.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
         <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version>
         <httpcomponents.httpasyncclient.version>4.1.4</httpcomponents.httpasyncclient.version>
         <httpcomponents.httpmime.version>4.5.13</httpcomponents.httpmime.version>
-        <io.opentelemetry.version>1.15.0</io.opentelemetry.version>
-        <io.opentelemetry-semconv.version>1.15.0-alpha</io.opentelemetry-semconv.version>
+        <io.opentelemetry.version>1.62.0</io.opentelemetry.version>
+        <io.opentelemetry-semconv.version>1.29.0-alpha</io.opentelemetry-semconv.version>
         <javax.persistence.version>2.1.0</javax.persistence.version>
         <javax.servlet.version>4.0.0</javax.servlet.version>
         <javax-inject.version>1</javax-inject.version>


### PR DESCRIPTION
HBase on nightly/ODP-3.2.3.7-2 uses opentelemetry 1.62.0 / semconv 1.29.0-alpha, but Ranger was pinned at 1.15.0 / 1.15.0-alpha. The HBase Ranger plugin then loaded hbase-client classes built against the newer semconv against the older jars, so test connection failed with:
  NoClassDefFoundError: Could not initialize class
  org.apache.hadoop.hbase.trace.HBaseSemanticAttributes

Bump Ranger to match HBase and fix the semconv Maven coordinates (the opentelemetry-semconv artifact moved to groupId io.opentelemetry.semconv for 1.29.0-alpha):
  - pom.xml: io.opentelemetry.version 1.15.0 -> 1.62.0, io.opentelemetry-semconv.version 1.15.0-alpha -> 1.29.0-alpha
  - hbase-agent/pom.xml: semconv groupId io.opentelemetry -> io.opentelemetry.semconv
  - distro admin-web.xml assembly: same groupId fix so the matching jar is bundled

No Ranger source/API change (Ranger has zero io.opentelemetry imports; deps are packaging-only for the HBase plugin classpath).

## How was this patch tested?
Tested locally
