### PR TITLE
ODP-7045 Resolve _HOST in Kafka client JAAS principal for Ranger test connection

### DIFF
--- a/plugin-kafka/src/main/java/org/apache/ranger/services/kafka/client/ServiceKafkaClient.java
+++ b/plugin-kafka/src/main/java/org/apache/ranger/services/kafka/client/ServiceKafkaClient.java
@@ -232,6 +232,18 @@ public class ServiceKafkaClient {
 	}
 
 	private String getJAASConfig(Map<String,String> configs){
+		// Resolve _HOST in the principal to this node's FQDN so a single stored value
+		// (e.g. ambari-qa/_HOST@REALM) authenticates on whichever Ranger Admin node runs
+		// the test/lookup -- works for both standalone and HA Ranger.
+		String principal = configs.get(KEY_KAFKA_PRINCIPAL);
+		if (principal != null && principal.contains("_HOST")) {
+			try {
+				principal = principal.replace("_HOST",
+						java.net.InetAddress.getLocalHost().getCanonicalHostName().toLowerCase());
+			} catch (java.net.UnknownHostException e) {
+				LOG.warn("Could not resolve local host to replace _HOST in principal: " + principal, e);
+			}
+		}
 		String jaasConfig =  new StringBuilder()
 				.append(JAAS_KRB5_MODULE).append(" ")
 				.append(JAAS_USE_KEYTAB).append(" ")
@@ -239,7 +251,7 @@ public class ServiceKafkaClient {
 				.append(JAAS_STOKE_KEY).append(" ")
 				.append(JAAS_USER_TICKET_CACHE).append(" ")
 				.append(JAAS_SERVICE_NAME).append(" ")
-				.append(JAAS_PRINCIPAL).append(configs.get(KEY_KAFKA_PRINCIPAL)).append("\";")
+				.append(JAAS_PRINCIPAL).append(principal).append("\";")
 				.toString();
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("KafkaClient JAAS: " + jaasConfig);


### PR DESCRIPTION
… connection

The Ranger Kafka repo now stores kafka.principal with _HOST unresolved (e.g. ambari-qa/_HOST@REALM, set by KAFKA3 mpack and the companion odp-ambari change). ServiceKafkaClient.getJAASConfig() inserted the principal verbatim, so the KafkaAdminClient kinit got a literal _HOST and failed with 'Could not login: client is being asked for a password'.

Resolve _HOST to this node's canonical FQDN before building the JAAS, so a single stored value authenticates on whichever Ranger Admin node runs the test/lookup -- correct for both standalone and HA Ranger, and for both kafka (2.8.2) and kafka3 (3.7.2) brokers. No other Ranger code uses opentelemetry-style packaging here; this is the only consumer.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?

Tested locally by creating kafka-ranger plugin jar
