### PR TITLE
OSV-22568: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <mockito.version>3.0.0</mockito.version>
         <mockito.all.version>1.10.19</mockito.all.version>
         <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
-        <netty-all.version>4.1.132.Final</netty-all.version>
+        <netty-all.version>4.1.135.Final</netty-all.version>
         <noggit.version>0.8</noggit.version>
         <orc.core.version>1.6.7</orc.core.version>
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (12)
OSV-22568, OSV-22576, OSV-22590, OSV-22633, OSV-22634, OSV-22635, OSV-22636, OSV-22637, OSV-22638, OSV-22639, OSV-22644, OSV-22678
