### PR TITLE
OSV-22482 - CVE - Bumped-up Jackson to 2.18.6 to address PRISMA-2023-0067

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,8 +217,8 @@
         <zookeeper.version>3.8.4.3.3.6.5-SNAPSHOT</zookeeper.version>
         <codehaus.woodstox.stax2api.version>4.2.1</codehaus.woodstox.stax2api.version>
         <fasterxml.woodstox.version>5.4.0</fasterxml.woodstox.version>
-        <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
-        <fasterxml.jackson.databind.version>2.17.2</fasterxml.jackson.databind.version>
+        <fasterxml.jackson.version>2.18.6</fasterxml.jackson.version>
+        <fasterxml.jackson.databind.version>2.18.6</fasterxml.jackson.databind.version>
         <kstruct.gethostname4j.version>1.0.0</kstruct.gethostname4j.version>
         <jna.version>5.7.0</jna.version>
         <jna-platform.version>5.7.0</jna-platform.version>

--- a/ranger-yunikorn-agent/pom.xml
+++ b/ranger-yunikorn-agent/pom.xml
@@ -66,7 +66,7 @@
              manage these, so the agent stays in control of its own classpath. -->
         <fabric8.version>6.13.4</fabric8.version>
         <snakeyaml.version>2.2</snakeyaml.version>
-        <jackson.version>2.16.1</jackson.version>
+        <jackson.version>2.18.6</jackson.version>
         <slf4j.version>2.0.13</slf4j.version>
         <log4j2.version>2.23.1</log4j2.version>
         <commons.lang3.version>3.14.0</commons.lang3.version>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-22482, OSV-22483, OSV-22484, OSV-22502, OSV-22508, OSV-22532, OSV-22602, OSV-22603, OSV-22604, OSV-22605