### PR TITLE
OSV-22548 - CVE - Bumped-up Tomcat to 9.0.120 to address CVE-2026-24880/CVE-2026-25854/CVE-2026-29129/CVE-2026-29145/CVE-2026-29146/CVE-2026-32990/...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
         <sqoop.version>1.4.8.3.3.6.5-SNAPSHOT</sqoop.version>
         <storm.version>1.2.4</storm.version>
         <sun-jersey-bundle.version>1.19</sun-jersey-bundle.version>
-        <tomcat.embed.version>9.0.115</tomcat.embed.version>
+        <tomcat.embed.version>9.0.120</tomcat.embed.version>
         <testng.version>7.5.1</testng.version>
         <velocity.version>2.4.1</velocity.version>
         <zookeeper.version>3.8.4.3.3.6.5-SNAPSHOT</zookeeper.version>


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `tomcat.embed.version` → `9.0.120`
- Tickets: OSV-22548, OSV-22549, OSV-22550, OSV-22551, OSV-22552, OSV-22553, OSV-22554, OSV-22555, OSV-22556, OSV-22557, OSV-22558, OSV-22559, OSV-22560, OSV-22561, OSV-22562, OSV-22563
- Advisories: CVE-2026-24880, CVE-2026-25854, CVE-2026-29129, CVE-2026-29145, CVE-2026-29146, CVE-2026-32990, CVE-2026-34483, CVE-2026-34487, CVE-2026-34500, CVE-2026-41284, CVE-2026-41293, CVE-2026-42498, CVE-2026-43512, CVE-2026-43513, CVE-2026-43514, CVE-2026-43515