### PR TITLE
OSV-22504 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <commons.digester.version>2.1</commons.digester.version>
         <commons.io.version>2.17.0</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>
-        <commons.lang3.version>3.3.2</commons.lang3.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
         <commons.logging.version>1.3.5</commons.logging.version>
         <commons.math.version>2.2</commons.math.version>
         <commons.net.version>3.9.0</commons.net.version>


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `commons.lang3.version` → `3.18.0`
- Tickets: OSV-22504, OSV-22649
- Advisories: CVE-2025-48924