### PR TITLE
OSV-22577 - CVE - Bumped-up commons-configuration2 to 2.15.0 to address CVE-2026-45205

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compress.version>1.27.1</commons.compress.version>
         <commons.configuration1.version>1.10</commons.configuration1.version>
-        <commons.configuration.version>2.10.1</commons.configuration.version>
+        <commons.configuration.version>2.15.0</commons.configuration.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <commons.digester.version>2.1</commons.digester.version>
         <commons.io.version>2.17.0</commons.io.version>


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `commons.configuration.version` → `2.15.0`
- Tickets: OSV-22577
- Advisories: CVE-2026-45205