### PR TITLE
OSV-22646 - CVE - Bumped-up nimbus-jose-jwt to 10.0.2 to address CVE-2025-53864

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <lucene.version>8.11.3</lucene.version>
         <hppc.version>0.8.0</hppc.version>
         <joda.time.version>2.10.6</joda.time.version>
-        <nimbus-jose-jwt.version>10.0.1</nimbus-jose-jwt.version>
+        <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
         <aws-java-sdk.version>1.12.780</aws-java-sdk.version>
 
         <!-- GCP HSM -->


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `nimbus-jose-jwt.version` → `10.0.2`
- Tickets: OSV-22646
- Advisories: CVE-2025-53864