### PR TITLE
OSV-22565 - CVE - Bumped-up logback to 1.3.16 to address CVE-2024-12798/CVE-2024-12801/CVE-2025-11226

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <kylin.version>4.0.4</kylin.version>
         <libpam4j.version>1.10</libpam4j.version>
         <local.lib.dir>${project.basedir}/../lib/local</local.lib.dir>
-        <logback.version>1.3.14</logback.version>
+        <logback.version>1.3.16</logback.version>
         <reload4j.version>1.2.19</reload4j.version>
         <log4j2.version>2.17.2</log4j2.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `logback.version` → `1.3.16`
- Tickets: OSV-22565, OSV-22566, OSV-22567
- Advisories: CVE-2024-12798, CVE-2024-12801, CVE-2025-11226