### PR TITLE
OSV-22523 - CVE - Bumped-up poi to 5.4.0 to address CVE-2025-31672

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <paranamer.version>2.3</paranamer.version>
         <presto.version>333</presto.version>
         <trino.version>472.3.3.6.5-SNAPSHOT</trino.version>
-        <poi.version>5.2.2</poi.version>
+        <poi.version>5.4.0</poi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <gcp.protobuf-java.version>3.25.5</gcp.protobuf-java.version>


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `poi.version` → `5.4.0`
- Tickets: OSV-22523
- Advisories: CVE-2025-31672