### PR TITLE
OSV-22495 - CVE - Bumped-up opentelemetry to 1.62.0 to address CVE-2026-45292

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <httpcomponents.httpcore.version>4.4.14</httpcomponents.httpcore.version>
         <httpcomponents.httpasyncclient.version>4.1.4</httpcomponents.httpasyncclient.version>
         <httpcomponents.httpmime.version>4.5.13</httpcomponents.httpmime.version>
-        <io.opentelemetry.version>1.49.0</io.opentelemetry.version>
+        <io.opentelemetry.version>1.62.0</io.opentelemetry.version>
         <io.opentelemetry-semconv.version>1.29.0-alpha</io.opentelemetry-semconv.version>
         <javax.persistence.version>2.1.0</javax.persistence.version>
         <javax.servlet.version>4.0.0</javax.servlet.version>


### PR DESCRIPTION
- Component: ranger (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Property: `io.opentelemetry.version` → `1.62.0`
- Tickets: OSV-22495
- Advisories: CVE-2026-45292