### PR TITLE
XDP-1809: Set users with isVisible=0 to isVisible=1 if they are present in admin central

### DIFF
--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/AdminCentralResponseParser.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/AdminCentralResponseParser.java
@@ -22,6 +22,7 @@ package org.apache.ranger.unixusersync.process;
 import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 /**
@@ -29,7 +30,51 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
  */
 public final class AdminCentralResponseParser {
 
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	/** Admin Central application-level failure code (see XDP CP identity APIs). */
+	public static final int ERROR_CODE_FAILURE = 1;
+
 	private AdminCentralResponseParser() {
+	}
+
+	/**
+	 * Returns the Admin Central {@code message} when the JSON envelope indicates failure
+	 * ({@code errorCode == 1}); otherwise {@code null}.
+	 */
+	public static String apiErrorMessageIfPresent(JsonNode root) {
+		if (root == null || root.isNull() || !root.isObject()) {
+			return null;
+		}
+		JsonNode errorCode = root.get("errorCode");
+		if (errorCode == null || errorCode.isNull() || !errorCode.isNumber()
+				|| errorCode.asInt() != ERROR_CODE_FAILURE) {
+			return null;
+		}
+		String message = textOrNull(root.get("message"));
+		if (StringUtils.isNotBlank(message)) {
+			return message.trim();
+		}
+		String detailed = textOrNull(root.get("detailedMessage"));
+		if (StringUtils.isNotBlank(detailed)) {
+			return detailed.trim();
+		}
+		return "Admin Central API returned errorCode=" + ERROR_CODE_FAILURE;
+	}
+
+	/**
+	 * Same as {@link #apiErrorMessageIfPresent(JsonNode)} for a raw JSON body string.
+	 * Returns {@code null} if the body is blank or not a JSON object error envelope.
+	 */
+	public static String apiErrorMessageIfPresent(String jsonBody) {
+		if (StringUtils.isBlank(jsonBody)) {
+			return null;
+		}
+		try {
+			return apiErrorMessageIfPresent(MAPPER.readTree(jsonBody));
+		} catch (Exception e) {
+			return null;
+		}
 	}
 
 	public static JsonNode navigate(JsonNode root, String dotPath) {

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/AdminCentralRestClient.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/AdminCentralRestClient.java
@@ -148,8 +148,19 @@ final class AdminCentralRestClient {
 			IOUtils.copy(stream, buffer);
 		}
 		String body = buffer.toString(StandardCharsets.UTF_8.name());
+		String apiError = AdminCentralResponseParser.apiErrorMessageIfPresent(body);
+		if (apiError != null) {
+			LOG.error("Admin Central API error from {}: errorCode=1, message={}", urlString, apiError);
+		}
 		if (code < 200 || code >= 300) {
+			if (apiError != null) {
+				throw new IOException("HTTP " + code + " from " + urlString + ": " + apiError);
+			}
 			throw new IOException("HTTP " + code + " from " + urlString + ": " + body);
+		}
+		if (apiError != null) {
+			// HTTP 2xx with application-level error envelope (errorCode=1)
+			throw new IOException("Admin Central API error from " + urlString + ": " + apiError);
 		}
 		return body;
 	}

--- a/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
+++ b/ugsync/src/main/java/org/apache/ranger/unixusersync/process/PolicyMgrUserGroupBuilder.java
@@ -676,12 +676,14 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 				Map<String, String> curGroupAttrs  = curGroup.getOtherAttrsMap();
 				String curGroupDN                  = MapUtils.isEmpty(curGroupAttrs) ? groupName : curGroupAttrs.get(UgsyncCommonConstants.FULL_NAME);
 				String newSyncSource               = newGroupAttrs.get(UgsyncCommonConstants.SYNC_SOURCE);
+				boolean needsVisibilityRestore     = isHidden(curGroup.getIsVisible());
 
 				if (isStartupFlag && !isSyncSourceValidationEnabled && (!StringUtils.equalsIgnoreCase(curSyncSource, newSyncSource))) {
 					if (LOG.isDebugEnabled()) {
 						LOG.debug("[" + groupName + "]: SyncSource updated to " + newSyncSource + ", previous value: " + curSyncSource);
 					}
 					curGroup = setOtherAttributes(curGroup, newSyncSource, newGroupAttrs, newGroupAttrsStr);
+					restoreVisibility(curGroup, groupName);
 					deltaGroups.put(groupName, curGroup);
 					noOfModifiedGroups++;
 					groupNameMap.put(groupDN, groupName);
@@ -707,10 +709,17 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 							}
 						}
 						curGroup = setOtherAttributes(curGroup, newSyncSource, newGroupAttrs, newGroupAttrsStr);
+						restoreVisibility(curGroup, groupName);
 						deltaGroups.put(groupName, curGroup);
 						noOfModifiedGroups++;
 						groupNameMap.put(groupDN, groupName);
 
+					} else if (needsVisibilityRestore) {
+						// Soft-deleted group reappeared in sync source with no other attribute changes.
+						restoreVisibility(curGroup, groupName);
+						deltaGroups.put(groupName, curGroup);
+						noOfModifiedGroups++;
+						groupNameMap.put(groupDN, groupName);
 					} else if (LOG.isDebugEnabled()) {
 						if (!StringUtils.equalsIgnoreCase(curSyncSource, newSyncSource)) {
 							LOG.debug("[" + groupName + "]: Different sync source exists, update skipped!");
@@ -771,12 +780,14 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 				Map<String, String> curUserAttrs = curUser.getOtherAttrsMap();
 				String curUserDN                 = MapUtils.isEmpty(curUserAttrs) ? userName : curUserAttrs.get(UgsyncCommonConstants.FULL_NAME);
 				String newSyncSource             = newUserAttrs.get(UgsyncCommonConstants.SYNC_SOURCE);
+				boolean needsVisibilityRestore   = isHidden(curUser.getIsVisible());
 				if (isStartupFlag && !isSyncSourceValidationEnabled && (!StringUtils.equalsIgnoreCase(curSyncSource, newSyncSource))) {
 					if (LOG.isDebugEnabled()) {
 						LOG.debug("[" + userName + "]: SyncSource updated to " + newSyncSource + ", previous value: " + curSyncSource);
 					}
 					curUser = setOtherAttributes(curUser, newSyncSource, newUserAttrs, newUserAttrsStr);
 					curUser.setUserSource(SOURCE_EXTERNAL);
+					restoreVisibility(curUser, userName);
 					deltaUsers.put(userName, curUser);
 					noOfModifiedGroups++;
 					userNameMap.put(userDN, userName);
@@ -803,6 +814,13 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 						}
 						curUser = setOtherAttributes(curUser, newSyncSource, newUserAttrs, newUserAttrsStr);
 						curUser.setUserSource(SOURCE_EXTERNAL);
+						restoreVisibility(curUser, userName);
+						deltaUsers.put(userName, curUser);
+						noOfModifiedUsers++;
+						userNameMap.put(userDN, userName);
+					} else if (needsVisibilityRestore) {
+						// Soft-deleted user reappeared in sync source with no other attribute changes.
+						restoreVisibility(curUser, userName);
 						deltaUsers.put(userName, curUser);
 						noOfModifiedUsers++;
 						userNameMap.put(userDN, userName);
@@ -1846,9 +1864,10 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 			if (StringUtils.isNotEmpty(userDN) && !sourceUsers.containsKey(userDN)
 					&& StringUtils.equalsIgnoreCase(userOtherAttrs.get(UgsyncCommonConstants.SYNC_SOURCE), currentSyncSource)
 					&& StringUtils.equalsIgnoreCase(userOtherAttrs.get(UgsyncCommonConstants.LDAP_URL), ldapUrl)) {
-				if (userInfo.getIsVisible() != ISHIDDEN) {
-				userInfo.setIsVisible(ISHIDDEN);
-				deletedUsers.put(userInfo.getName(), userInfo);
+				if (!ISHIDDEN.equals(userInfo.getIsVisible())) {
+					userInfo.setIsVisible(ISHIDDEN);
+					deletedUsers.put(userInfo.getName(), userInfo);
+					LOG.info("user " + userInfo.getName() + " marked for delete ");
 				} else {
 					LOG.info("user " + userInfo.getName() + " already marked for delete ");
 				}
@@ -1941,10 +1960,59 @@ public class PolicyMgrUserGroupBuilder extends AbstractUserGroupSource implement
 		return ret;
 	}
 
+	private static boolean isHidden(String isVisible) {
+		return !ISVISIBLE.equals(isVisible);
+	}
+
+	private void restoreVisibility(XUserInfo userInfo, String userName) {
+		if (userInfo != null && isHidden(userInfo.getIsVisible())) {
+			userInfo.setIsVisible(ISVISIBLE);
+			LOG.info("[" + userName + "]: Visibility restored to Visible (was soft-deleted)");
+		}
+	}
+
+	private void restoreVisibility(XGroupInfo groupInfo, String groupName) {
+		if (groupInfo != null && isHidden(groupInfo.getIsVisible())) {
+			groupInfo.setIsVisible(ISVISIBLE);
+			LOG.info("[" + groupName + "]: Visibility restored to Visible (was soft-deleted)");
+		}
+	}
+
 	//Only for testing purpose
 	protected void setUserSyncNameValidationEnabled(String isNameValidationEnabled) {
 		config.setProperty(UserGroupSyncConfig.UGSYNC_NAME_VALIDATION_ENABLED, isNameValidationEnabled);
 		this.isUserSyncNameValidationEnabled = config.isUserSyncNameValidationEnabled();
+	}
+
+	// Only for testing purpose
+	protected void setCachesForTest(Map<String, XUserInfo> users, Map<String, XGroupInfo> groups,
+			Map<String, String> userDnToName, Map<String, String> groupDnToName) {
+		this.userCache = users != null ? users : new HashMap<>();
+		this.groupCache = groups != null ? groups : new HashMap<>();
+		this.userNameMap = userDnToName != null ? userDnToName : new HashMap<>();
+		this.groupNameMap = groupDnToName != null ? groupDnToName : new HashMap<>();
+		this.deltaUsers = new HashMap<>();
+		this.deltaGroups = new HashMap<>();
+		this.noOfNewUsers = 0;
+		this.noOfNewGroups = 0;
+		this.noOfModifiedUsers = 0;
+		this.noOfModifiedGroups = 0;
+		this.isStartupFlag = false;
+		this.isSyncSourceValidationEnabled = true;
+		this.policyMgrUserName = "rangerusersync";
+		this.isUserSyncNameValidationEnabled = false;
+	}
+
+	// Only for testing purpose
+	protected Map<String, XUserInfo> computeUserDeltaForTest(Map<String, Map<String, String>> sourceUsers) {
+		computeUserDelta(sourceUsers);
+		return deltaUsers;
+	}
+
+	// Only for testing purpose
+	protected Map<String, XGroupInfo> computeGroupDeltaForTest(Map<String, Map<String, String>> sourceGroups) {
+		computeGroupDelta(sourceGroups);
+		return deltaGroups;
 	}
 
 	// This will throw RuntimeException if Server is not Active

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestAdminCentralResponseParser.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestAdminCentralResponseParser.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -91,5 +92,38 @@ class TestAdminCentralResponseParser {
 		assertNotNull(content);
 		assertEquals(1, content.size());
 		assertEquals("alice", content.get(0).get("username").asText());
+	}
+
+	@Test
+	void apiErrorMessageIfPresentReturnsMessageWhenErrorCodeIsOne() throws Exception {
+		String json =
+				"{"
+						+ "\"errorCode\":1,"
+						+ "\"success\":false,"
+						+ "\"message\":\"Failed to fetch users: {  \\\"message\\\" : \\\"User  dataplane-service-user should have view:serviceUsers permissions\\\"}\","
+						+ "\"detailedMessage\":\"{  \\\"message\\\" : \\\"User  dataplane-service-user should have view:serviceUsers permissions\\\"}\","
+						+ "\"data\":null,"
+						+ "\"meta\":null"
+						+ "}";
+		JsonNode root = mapper.readTree(json);
+		String msg = AdminCentralResponseParser.apiErrorMessageIfPresent(root);
+		assertNotNull(msg);
+		assertTrue(msg.contains("view:serviceUsers"));
+		assertEquals(msg, AdminCentralResponseParser.apiErrorMessageIfPresent(json));
+	}
+
+	@Test
+	void apiErrorMessageIfPresentReturnsNullForSuccessEnvelope() throws Exception {
+		String json = "{\"errorCode\":0,\"success\":true,\"message\":null,\"data\":{\"users\":[]}}";
+		assertNull(AdminCentralResponseParser.apiErrorMessageIfPresent(json));
+		assertNull(AdminCentralResponseParser.apiErrorMessageIfPresent(mapper.readTree(json)));
+	}
+
+	@Test
+	void apiErrorMessageIfPresentFallsBackToDetailedMessage() throws Exception {
+		ObjectNode root = mapper.createObjectNode();
+		root.put("errorCode", 1);
+		root.put("detailedMessage", "permission denied");
+		assertEquals("permission denied", AdminCentralResponseParser.apiErrorMessageIfPresent(root));
 	}
 }

--- a/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilderVisibility.java
+++ b/ugsync/src/test/java/org/apache/ranger/unixusersync/process/TestPolicyMgrUserGroupBuilderVisibility.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.unixusersync.process;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.ranger.authorization.utils.JsonUtils;
+import org.apache.ranger.ugsyncutil.model.XGroupInfo;
+import org.apache.ranger.ugsyncutil.model.XUserInfo;
+import org.apache.ranger.ugsyncutil.util.UgsyncCommonConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TestPolicyMgrUserGroupBuilderVisibility {
+
+	private static final String IS_VISIBLE = "1";
+	private static final String IS_HIDDEN = "0";
+	private static final String SYNC_SOURCE = "Admin Central";
+
+	private PolicyMgrUserGroupBuilder sink;
+
+	@BeforeEach
+	void setUp() {
+		sink = new PolicyMgrUserGroupBuilder();
+	}
+
+	@Test
+	void computeUserDeltaRestoresVisibilityWhenSoftDeletedUserReappears() {
+		String userName = "alice";
+		Map<String, String> attrs = attrsFor(userName);
+
+		XUserInfo cached = new XUserInfo();
+		cached.setName(userName);
+		cached.setSyncSource(SYNC_SOURCE);
+		cached.setOtherAttrsMap(attrs);
+		cached.setOtherAttributes(JsonUtils.objectToJson(attrs));
+		cached.setIsVisible(IS_HIDDEN);
+
+		Map<String, XUserInfo> userCache = new HashMap<>();
+		userCache.put(userName, cached);
+		Map<String, String> userNameMap = new HashMap<>();
+		userNameMap.put(userName, userName);
+		sink.setCachesForTest(userCache, null, userNameMap, null);
+
+		Map<String, Map<String, String>> sourceUsers = new HashMap<>();
+		sourceUsers.put(userName, attrs);
+
+		Map<String, XUserInfo> delta = sink.computeUserDeltaForTest(sourceUsers);
+
+		assertTrue(delta.containsKey(userName));
+		assertEquals(IS_VISIBLE, delta.get(userName).getIsVisible());
+		assertEquals(IS_VISIBLE, cached.getIsVisible());
+	}
+
+	@Test
+	void computeUserDeltaSkipsAlreadyVisibleUserWithNoChanges() {
+		String userName = "bob";
+		Map<String, String> attrs = attrsFor(userName);
+
+		XUserInfo cached = new XUserInfo();
+		cached.setName(userName);
+		cached.setSyncSource(SYNC_SOURCE);
+		cached.setOtherAttrsMap(attrs);
+		cached.setOtherAttributes(JsonUtils.objectToJson(attrs));
+		cached.setIsVisible(IS_VISIBLE);
+
+		Map<String, XUserInfo> userCache = new HashMap<>();
+		userCache.put(userName, cached);
+		Map<String, String> userNameMap = new HashMap<>();
+		userNameMap.put(userName, userName);
+		sink.setCachesForTest(userCache, null, userNameMap, null);
+
+		Map<String, Map<String, String>> sourceUsers = new HashMap<>();
+		sourceUsers.put(userName, attrs);
+
+		Map<String, XUserInfo> delta = sink.computeUserDeltaForTest(sourceUsers);
+
+		assertFalse(delta.containsKey(userName));
+		assertEquals(IS_VISIBLE, cached.getIsVisible());
+	}
+
+	@Test
+	void computeGroupDeltaRestoresVisibilityWhenSoftDeletedGroupReappears() {
+		String groupName = "engineers";
+		Map<String, String> attrs = attrsFor(groupName);
+
+		XGroupInfo cached = new XGroupInfo();
+		cached.setName(groupName);
+		cached.setSyncSource(SYNC_SOURCE);
+		cached.setOtherAttrsMap(attrs);
+		cached.setOtherAttributes(JsonUtils.objectToJson(attrs));
+		cached.setIsVisible(IS_HIDDEN);
+
+		Map<String, XGroupInfo> groupCache = new HashMap<>();
+		groupCache.put(groupName, cached);
+		Map<String, String> groupNameMap = new HashMap<>();
+		groupNameMap.put(groupName, groupName);
+		sink.setCachesForTest(null, groupCache, null, groupNameMap);
+
+		Map<String, Map<String, String>> sourceGroups = new HashMap<>();
+		sourceGroups.put(groupName, attrs);
+
+		Map<String, XGroupInfo> delta = sink.computeGroupDeltaForTest(sourceGroups);
+
+		assertTrue(delta.containsKey(groupName));
+		assertEquals(IS_VISIBLE, delta.get(groupName).getIsVisible());
+		assertEquals(IS_VISIBLE, cached.getIsVisible());
+	}
+
+	private static Map<String, String> attrsFor(String name) {
+		Map<String, String> attrs = new HashMap<>();
+		attrs.put(UgsyncCommonConstants.ORIGINAL_NAME, name);
+		attrs.put(UgsyncCommonConstants.FULL_NAME, name);
+		attrs.put(UgsyncCommonConstants.SYNC_SOURCE, SYNC_SOURCE);
+		return attrs;
+	}
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Usersync managed to set users/groups to not visible but could not do the reverse. This patch seeks to bridge that gap

CAVEAT: 

If a user is set to isVisible=0 from some path other than usersync then the ranger-usersync pod needs to be restarted for it to pick up that change. Usersync pod maintains user and group info in cache which is invalidated only when the pod is killed and new pod picks up the info from latest ranger db

In future we can add some cache invalidation after N cycles of usersync

## How was this patch tested?

Tested by manually setting a user to isVisible=0 by calling ranger admin API and then restarting usersync pod