### PR TITLE
Revert "CVE-2023-2976 | Bump guava to 32.1.3-jre" to fix ODP-7384

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <elasticsearch.version>7.17.29</elasticsearch.version>
         <enunciate.version>2.13.2</enunciate.version>
         <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
-        <google.guava.version>32.1.3-jre</google.guava.version>
+        <google.guava.version>27.0-jre</google.guava.version>
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>
         <graalvm.version>22.3.0</graalvm.version>
         <gson.version>2.9.0</gson.version>


### PR DESCRIPTION
… directory vulnerability" to fix ODP-7384

This reverts commit 0046c6234f8bb1b302215bd2a226c351c0c5f91b.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix. Create an issue in ASF JIRA before opening a pull request and
set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RANGER-XXXX: Fix a typo in YYY))


## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
