### PR TITLE
ODP-7407: Backport commits from 3.3.6.x to 3.2.3.7-2 (Ranger RMS)

### DIFF
--- a/agents-common/src/main/java/org/apache/ranger/admin/client/AbstractRangerAdminClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/AbstractRangerAdminClient.java
@@ -126,6 +126,10 @@ public abstract class AbstractRangerAdminClient implements RangerAdminClient {
         return null;
     }
 
+    @Override
+    public ServiceRMSMappings getRMSMappings(String serviceName, Long lastKnownVersion) throws Exception {
+        return null;
+    }
 
     public boolean isKerberosEnabled(UserGroupInformation user) {
         final boolean ret;

--- a/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminClient.java
@@ -27,6 +27,7 @@ import org.apache.ranger.plugin.util.GrantRevokeRoleRequest;
 import org.apache.ranger.plugin.util.RangerRoles;
 import org.apache.ranger.plugin.util.ServiceGdsInfo;
 import org.apache.ranger.plugin.util.ServicePolicies;
+import org.apache.ranger.plugin.util.ServiceRMSMappings;
 import org.apache.ranger.plugin.util.ServiceTags;
 import org.apache.ranger.plugin.util.RangerUserStore;
 
@@ -66,4 +67,13 @@ public interface RangerAdminClient {
 	RangerUserStore getUserStoreIfUpdated(long lastKnownUserStoreVersion, long lastActivationTimeInMillis) throws Exception;
 
 	ServiceGdsInfo getGdsInfoIfUpdated(long lastKnownVersion, long lastActivationTimeInMillis) throws Exception;
+
+	/**
+	 * Get RMS (Resource Mapping Server) mappings for Hive-to-Storage policy sync.
+	 * @param serviceName The storage service name (HDFS, Ozone, S3)
+	 * @param lastKnownVersion The last known mapping version (for incremental updates)
+	 * @return ServiceRMSMappings containing resource mappings, or null if no updates
+	 * @throws Exception on error
+	 */
+	ServiceRMSMappings getRMSMappings(String serviceName, Long lastKnownVersion) throws Exception;
 }

--- a/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminRESTClient.java
+++ b/agents-common/src/main/java/org/apache/ranger/admin/client/RangerAdminRESTClient.java
@@ -1393,4 +1393,69 @@ public class RangerAdminRESTClient extends AbstractRangerAdminClient {
 			isValidRoleDownloadSessionCookie = (roleDownloadSessionId != null);
 		}
 	}
+
+	/**
+	 * Get RMS mappings from Ranger Admin (RMS endpoint).
+	 */
+	@Override
+	public ServiceRMSMappings getRMSMappings(String serviceName, Long lastKnownVersion) throws Exception {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("==> RangerAdminRESTClient.getRMSMappings(" + serviceName + ", " + lastKnownVersion + ")");
+		}
+
+		ServiceRMSMappings ret = null;
+
+		UserGroupInformation user = MiscUtil.getUGILoginUser();
+		boolean isSecureMode = isKerberosEnabled(user);
+
+		Map<String, String> queryParams = new HashMap<String, String>();
+		if (lastKnownVersion != null) {
+			queryParams.put("lastKnownVersion", Long.toString(lastKnownVersion));
+		}
+		queryParams.put(RangerRESTUtils.REST_PARAM_PLUGIN_ID, pluginId);
+
+		String relativeURL = "/service/rms/mappings/download/" + serviceName;
+
+		ClientResponse response = null;
+
+		if (isSecureMode) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Getting RMS mappings as user: " + user);
+			}
+			final String finalRelativeURL = relativeURL;
+			final Map<String, String> finalQueryParams = queryParams;
+			response = MiscUtil.executePrivilegedAction((PrivilegedExceptionAction<ClientResponse>) () -> {
+				try {
+					return restClient.get(finalRelativeURL, finalQueryParams);
+				} catch (Exception e) {
+					LOG.error("Failed to get RMS mappings: " + e.getMessage());
+				}
+				return null;
+			});
+		} else {
+			response = restClient.get(relativeURL, queryParams);
+		}
+
+		if (response != null) {
+			int statusCode = response.getStatus();
+			if (statusCode == HttpServletResponse.SC_OK) {
+				ret = JsonUtilsV2.readResponse(response, ServiceRMSMappings.class);
+			} else if (statusCode == HttpServletResponse.SC_NOT_MODIFIED
+					|| statusCode == HttpServletResponse.SC_NO_CONTENT) {
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("No RMS mapping changes since last known version: {} (status={})", lastKnownVersion, statusCode);
+				}
+			} else if (statusCode == HttpServletResponse.SC_NOT_FOUND) {
+				LOG.warn("RMS endpoint not found - RMS may not be enabled on Ranger Admin");
+			} else {
+				LOG.warn("Error getting RMS mappings. statusCode=" + statusCode + ", serviceName=" + serviceName);
+			}
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("<== RangerAdminRESTClient.getRMSMappings(" + serviceName + ", " + lastKnownVersion + "): " + ret);
+		}
+
+		return ret;
+	}
 }

--- a/agents-common/src/main/java/org/apache/ranger/chainedplugin/hdfs/hive/RangerHdfsHiveChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/chainedplugin/hdfs/hive/RangerHdfsHiveChainedPlugin.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.chainedplugin.hdfs.hive;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessResource;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.apache.ranger.plugin.service.RangerRMSChainedPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * RangerHdfsHiveChainedPlugin enables Hive-HDFS ACL Sync (RMS).
+ * It evaluates Hive policies for HDFS access requests when the HDFS path
+ * maps to a Hive table/database.
+ *
+ * Configuration:
+ * - ranger.plugin.hdfs.chained.services = {hive_service_name}
+ * - ranger.plugin.hdfs.chained.services.{hive_service_name}.impl = org.apache.ranger.chainedplugin.hdfs.hive.RangerHdfsHiveChainedPlugin
+ *
+ * Access type mapping (HDFS -> Hive):
+ * - read -> select
+ * - write -> update, alter
+ * - execute -> _any
+ */
+public class RangerHdfsHiveChainedPlugin extends RangerRMSChainedPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerHdfsHiveChainedPlugin.class);
+
+    private static final String HDFS_SERVICE_TYPE = "hive";
+    private static final String HDFS_RESOURCE_PATH = "path";
+
+    public RangerHdfsHiveChainedPlugin(RangerBasePlugin rootPlugin, String serviceName) {
+        super(rootPlugin, HDFS_SERVICE_TYPE, serviceName);
+        LOG.info("RangerHdfsHiveChainedPlugin created for service: {}", serviceName);
+    }
+
+    @Override
+    protected String extractStoragePath(RangerAccessRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        RangerAccessResource resource = request.getResource();
+        if (resource == null) {
+            return null;
+        }
+
+        Object pathValue = resource.getValue(HDFS_RESOURCE_PATH);
+        if (pathValue != null) {
+            return pathValue.toString();
+        }
+
+        Map<String, Object> resourceAsMap = resource.getAsMap();
+        if (resourceAsMap != null && !resourceAsMap.isEmpty()) {
+            Object path = resourceAsMap.get(HDFS_RESOURCE_PATH);
+            if (path != null) {
+                return path.toString();
+            }
+        }
+
+        String resourceString = resource.getAsString();
+        if (StringUtils.isNotBlank(resourceString)) {
+            return resourceString;
+        }
+
+        return null;
+    }
+
+    @Override
+    public void init() {
+        LOG.info("==> RangerHdfsHiveChainedPlugin.init()");
+        super.init();
+        LOG.info("<== RangerHdfsHiveChainedPlugin.init(): Hive-HDFS ACL Sync enabled");
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/chainedplugin/ozone/hive/RangerOzoneHiveChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/chainedplugin/ozone/hive/RangerOzoneHiveChainedPlugin.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.chainedplugin.ozone.hive;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessResource;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.apache.ranger.plugin.service.RangerRMSChainedPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * RangerOzoneHiveChainedPlugin enables Hive-Ozone ACL Sync (RMS).
+ * It evaluates Hive policies for Ozone access requests when the Ozone key
+ * maps to a Hive table/database.
+ *
+ * Configuration:
+ * - ranger.plugin.ozone.chained.services = {hive_service_name}
+ * - ranger.plugin.ozone.chained.services.{hive_service_name}.impl = org.apache.ranger.chainedplugin.ozone.hive.RangerOzoneHiveChainedPlugin
+ *
+ * Access type mapping (Ozone -> Hive Table):
+ * - read -> select
+ * - write -> update
+ * - create -> create
+ * - list -> select
+ * - delete -> drop
+ * - read_acl -> select
+ * - write_acl -> update
+ *
+ * Access type mapping (Ozone -> Hive Database):
+ * - read -> _any
+ * - write -> update
+ * - create -> create
+ * - list -> select
+ * - delete -> drop
+ * - read_acl -> select
+ * - write_acl -> update
+ */
+public class RangerOzoneHiveChainedPlugin extends RangerRMSChainedPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerOzoneHiveChainedPlugin.class);
+
+    private static final String OZONE_SERVICE_TYPE = "hive";
+    private static final String OZONE_RESOURCE_VOLUME = "volume";
+    private static final String OZONE_RESOURCE_BUCKET = "bucket";
+    private static final String OZONE_RESOURCE_KEY = "key";
+
+    public RangerOzoneHiveChainedPlugin(RangerBasePlugin rootPlugin, String serviceName) {
+        super(rootPlugin, OZONE_SERVICE_TYPE, serviceName);
+        LOG.info("RangerOzoneHiveChainedPlugin created for service: {}", serviceName);
+    }
+
+    @Override
+    protected String extractStoragePath(RangerAccessRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        RangerAccessResource resource = request.getResource();
+        if (resource == null) {
+            return null;
+        }
+
+        StringBuilder pathBuilder = new StringBuilder();
+
+        String volume = getResourceValue(resource, OZONE_RESOURCE_VOLUME);
+        String bucket = getResourceValue(resource, OZONE_RESOURCE_BUCKET);
+        String key = getResourceValue(resource, OZONE_RESOURCE_KEY);
+
+        if (StringUtils.isNotBlank(volume)) {
+            pathBuilder.append("/").append(volume);
+        }
+
+        if (StringUtils.isNotBlank(bucket)) {
+            pathBuilder.append("/").append(bucket);
+        }
+
+        if (StringUtils.isNotBlank(key)) {
+            if (!key.startsWith("/")) {
+                pathBuilder.append("/");
+            }
+            pathBuilder.append(key);
+        }
+
+        String path = pathBuilder.toString();
+        return StringUtils.isNotBlank(path) ? path : null;
+    }
+
+    private String getResourceValue(RangerAccessResource resource, String key) {
+        Object value = resource.getValue(key);
+        if (value != null) {
+            return value.toString();
+        }
+
+        Map<String, Object> resourceAsMap = resource.getAsMap();
+        if (MapUtils.isNotEmpty(resourceAsMap)) {
+            Object mapValue = resourceAsMap.get(key);
+            if (mapValue != null) {
+                return mapValue.toString();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void init() {
+        LOG.info("==> RangerOzoneHiveChainedPlugin.init()");
+        super.init();
+        LOG.info("<== RangerOzoneHiveChainedPlugin.init(): Hive-Ozone ACL Sync enabled");
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/chainedplugin/s3/hive/RangerS3HiveChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/chainedplugin/s3/hive/RangerS3HiveChainedPlugin.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.chainedplugin.s3.hive;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessResource;
+import org.apache.ranger.plugin.service.RangerBasePlugin;
+import org.apache.ranger.plugin.service.RangerRMSChainedPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * RangerS3HiveChainedPlugin enables Hive-S3 ACL Sync (RMS).
+ * It evaluates Hive policies for S3 access requests when the S3 path
+ * maps to a Hive table/database.
+ *
+ * Configuration (in ranger-s3-security.xml on the S3 plugin host):
+ * - ranger.plugin.s3.chained.services = {hive_service_name}
+ * - ranger.plugin.s3.chained.services.{hive_service_name}.impl = org.apache.ranger.chainedplugin.s3.hive.RangerS3HiveChainedPlugin
+ *
+ * Access type mapping (S3 -> Hive):
+ * - read -> select
+ * - write -> update, alter
+ */
+public class RangerS3HiveChainedPlugin extends RangerRMSChainedPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerS3HiveChainedPlugin.class);
+
+    private static final String S3_SERVICE_TYPE = "hive";
+    private static final String S3_RESOURCE_BUCKET = "bucket";
+    private static final String S3_RESOURCE_PATH = "path";
+    private static final String S3_RESOURCE_OBJECT = "object";
+
+    public RangerS3HiveChainedPlugin(RangerBasePlugin rootPlugin, String serviceName) {
+        super(rootPlugin, S3_SERVICE_TYPE, serviceName);
+        LOG.info("RangerS3HiveChainedPlugin created for service: {}", serviceName);
+    }
+
+    @Override
+    protected String extractStoragePath(RangerAccessRequest request) {
+        if (request == null) {
+            return null;
+        }
+
+        RangerAccessResource resource = request.getResource();
+        if (resource == null) {
+            return null;
+        }
+
+        StringBuilder pathBuilder = new StringBuilder();
+
+        String bucket = getResourceValue(resource, S3_RESOURCE_BUCKET);
+        String path = getResourceValue(resource, S3_RESOURCE_PATH);
+
+        if (StringUtils.isBlank(path)) {
+            path = getResourceValue(resource, S3_RESOURCE_OBJECT);
+        }
+
+        if (StringUtils.isNotBlank(bucket)) {
+            pathBuilder.append(bucket);
+        }
+
+        if (StringUtils.isNotBlank(path)) {
+            if (pathBuilder.length() > 0 && !path.startsWith("/")) {
+                pathBuilder.append("/");
+            }
+            pathBuilder.append(path);
+        }
+
+        String fullPath = pathBuilder.toString();
+        return StringUtils.isNotBlank(fullPath) ? fullPath : null;
+    }
+
+    private String getResourceValue(RangerAccessResource resource, String key) {
+        Object value = resource.getValue(key);
+        if (value != null) {
+            return value.toString();
+        }
+
+        Map<String, Object> resourceAsMap = resource.getAsMap();
+        if (MapUtils.isNotEmpty(resourceAsMap)) {
+            Object mapValue = resourceAsMap.get(key);
+            if (mapValue != null) {
+                return mapValue.toString();
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public void init() {
+        LOG.info("==> RangerS3HiveChainedPlugin.init()");
+        super.init();
+        LOG.info("<== RangerS3HiveChainedPlugin.init(): Hive-S3 ACL Sync enabled");
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerRMSMapping.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerRMSMapping.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * RangerRMSMapping represents a mapping between a high-level resource (e.g., Hive table)
+ * and a low-level resource (e.g., HDFS path, S3 location, Ozone key).
+ * This is used by RMS (Resource Mapping Server) to enable Hive-to-Storage policy sync.
+ */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerRMSMapping implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long   id;
+    private Long   hlResourceId;
+    private Long   llResourceId;
+    private String hlServiceName;
+    private String llServiceName;
+    private Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements;
+    private Map<String, RangerPolicy.RangerPolicyResource> llResourceElements;
+    private Long   changeTimestamp;
+
+    public RangerRMSMapping() {
+    }
+
+    public RangerRMSMapping(Long hlResourceId, Long llResourceId, String hlServiceName, String llServiceName,
+                            Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements,
+                            Map<String, RangerPolicy.RangerPolicyResource> llResourceElements) {
+        this.hlResourceId = hlResourceId;
+        this.llResourceId = llResourceId;
+        this.hlServiceName = hlServiceName;
+        this.llServiceName = llServiceName;
+        this.hlResourceElements = hlResourceElements;
+        this.llResourceElements = llResourceElements;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getHlResourceId() {
+        return hlResourceId;
+    }
+
+    public void setHlResourceId(Long hlResourceId) {
+        this.hlResourceId = hlResourceId;
+    }
+
+    public Long getLlResourceId() {
+        return llResourceId;
+    }
+
+    public void setLlResourceId(Long llResourceId) {
+        this.llResourceId = llResourceId;
+    }
+
+    public String getHlServiceName() {
+        return hlServiceName;
+    }
+
+    public void setHlServiceName(String hlServiceName) {
+        this.hlServiceName = hlServiceName;
+    }
+
+    public String getLlServiceName() {
+        return llServiceName;
+    }
+
+    public void setLlServiceName(String llServiceName) {
+        this.llServiceName = llServiceName;
+    }
+
+    public Map<String, RangerPolicy.RangerPolicyResource> getHlResourceElements() {
+        return hlResourceElements;
+    }
+
+    public void setHlResourceElements(Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements) {
+        this.hlResourceElements = hlResourceElements;
+    }
+
+    public Map<String, RangerPolicy.RangerPolicyResource> getLlResourceElements() {
+        return llResourceElements;
+    }
+
+    public void setLlResourceElements(Map<String, RangerPolicy.RangerPolicyResource> llResourceElements) {
+        this.llResourceElements = llResourceElements;
+    }
+
+    public Long getChangeTimestamp() {
+        return changeTimestamp;
+    }
+
+    public void setChangeTimestamp(Long changeTimestamp) {
+        this.changeTimestamp = changeTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("RangerRMSMapping={");
+        sb.append("id=").append(id);
+        sb.append(", hlResourceId=").append(hlResourceId);
+        sb.append(", llResourceId=").append(llResourceId);
+        sb.append(", hlServiceName=").append(hlServiceName);
+        sb.append(", llServiceName=").append(llServiceName);
+        sb.append(", hlResourceElements=").append(hlResourceElements);
+        sb.append(", llResourceElements=").append(llResourceElements);
+        sb.append(", changeTimestamp=").append(changeTimestamp);
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerRMSNotification.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/model/RangerRMSNotification.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * RangerRMSNotification represents a notification from HMS (Hive Metastore) about
+ * changes to database/table metadata. This is used by RMS to track incremental changes.
+ */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RangerRMSNotification implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    public enum ChangeType {
+        CREATE_DATABASE,
+        DROP_DATABASE,
+        ALTER_DATABASE,
+        CREATE_TABLE,
+        DROP_TABLE,
+        ALTER_TABLE,
+        ADD_PARTITION,
+        DROP_PARTITION,
+        ALTER_PARTITION
+    }
+
+    private Long       id;
+    private String     hmsName;
+    private Long       notificationId;
+    private Date       changeTimestamp;
+    private ChangeType changeType;
+    private Long       hlResourceId;
+    private Long       hlServiceId;
+    private Long       llResourceId;
+    private Long       llServiceId;
+    private String     databaseName;
+    private String     tableName;
+    private String     location;
+
+    public RangerRMSNotification() {
+    }
+
+    public RangerRMSNotification(String hmsName, Long notificationId, ChangeType changeType,
+                                  String databaseName, String tableName, String location) {
+        this.hmsName = hmsName;
+        this.notificationId = notificationId;
+        this.changeType = changeType;
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+        this.location = location;
+        this.changeTimestamp = new Date();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getHmsName() {
+        return hmsName;
+    }
+
+    public void setHmsName(String hmsName) {
+        this.hmsName = hmsName;
+    }
+
+    public Long getNotificationId() {
+        return notificationId;
+    }
+
+    public void setNotificationId(Long notificationId) {
+        this.notificationId = notificationId;
+    }
+
+    public Date getChangeTimestamp() {
+        return changeTimestamp;
+    }
+
+    public void setChangeTimestamp(Date changeTimestamp) {
+        this.changeTimestamp = changeTimestamp;
+    }
+
+    public ChangeType getChangeType() {
+        return changeType;
+    }
+
+    public void setChangeType(ChangeType changeType) {
+        this.changeType = changeType;
+    }
+
+    public Long getHlResourceId() {
+        return hlResourceId;
+    }
+
+    public void setHlResourceId(Long hlResourceId) {
+        this.hlResourceId = hlResourceId;
+    }
+
+    public Long getHlServiceId() {
+        return hlServiceId;
+    }
+
+    public void setHlServiceId(Long hlServiceId) {
+        this.hlServiceId = hlServiceId;
+    }
+
+    public Long getLlResourceId() {
+        return llResourceId;
+    }
+
+    public void setLlResourceId(Long llResourceId) {
+        this.llResourceId = llResourceId;
+    }
+
+    public Long getLlServiceId() {
+        return llServiceId;
+    }
+
+    public void setLlServiceId(Long llServiceId) {
+        this.llServiceId = llServiceId;
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public void setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("RangerRMSNotification={");
+        sb.append("id=").append(id);
+        sb.append(", hmsName=").append(hmsName);
+        sb.append(", notificationId=").append(notificationId);
+        sb.append(", changeTimestamp=").append(changeTimestamp);
+        sb.append(", changeType=").append(changeType);
+        sb.append(", databaseName=").append(databaseName);
+        sb.append(", tableName=").append(tableName);
+        sb.append(", location=").append(location);
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerRMSChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerRMSChainedPlugin.java
@@ -1,0 +1,517 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.service;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.authorization.hadoop.config.RangerChainedPluginConfig;
+import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequest;
+import org.apache.ranger.plugin.policyengine.RangerAccessRequestImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResourceImpl;
+import org.apache.ranger.plugin.policyengine.RangerAccessResult;
+import org.apache.ranger.plugin.policyengine.RangerResourceACLs;
+import org.apache.ranger.plugin.util.RangerRMSMappingCache;
+import org.apache.ranger.plugin.util.RangerRMSMappingCache.MappingEntry;
+import org.apache.ranger.plugin.util.RangerRMSMappingRefresher;
+import org.apache.ranger.plugin.util.ServiceRMSMappings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * RangerRMSChainedPlugin is the base class for RMS-enabled chained plugins.
+ * It provides functionality to:
+ * 1. Download and cache resource mappings from RMS
+ * 2. Lookup Hive resources from storage paths
+ * 3. Evaluate Hive policies for storage access requests
+ */
+public abstract class RangerRMSChainedPlugin extends RangerChainedPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerRMSChainedPlugin.class);
+
+    protected static final String HIVE_ACCESS_TYPE_SELECT = "select";
+    protected static final String HIVE_ACCESS_TYPE_UPDATE = "update";
+    protected static final String HIVE_ACCESS_TYPE_ALTER = "alter";
+    protected static final String HIVE_ACCESS_TYPE_CREATE = "create";
+    protected static final String HIVE_ACCESS_TYPE_DROP = "drop";
+    protected static final String HIVE_ACCESS_TYPE_ALL = "all";
+    protected static final String HIVE_ACCESS_TYPE_ANY = "_any";
+
+    protected static final String STORAGE_ACCESS_TYPE_READ = "read";
+    protected static final String STORAGE_ACCESS_TYPE_WRITE = "write";
+    protected static final String STORAGE_ACCESS_TYPE_EXECUTE = "execute";
+    protected static final String STORAGE_ACCESS_TYPE_LIST = "list";
+    protected static final String STORAGE_ACCESS_TYPE_CREATE = "create";
+    protected static final String STORAGE_ACCESS_TYPE_DELETE = "delete";
+    protected static final String STORAGE_ACCESS_TYPE_READ_ACL = "read_acl";
+    protected static final String STORAGE_ACCESS_TYPE_WRITE_ACL = "write_acl";
+
+    private final RangerRMSMappingCache mappingCache;
+    private final boolean authorizeOnlyWithChainedPlugin;
+    private final Map<String, List<String>> accessTypeMapping;
+    private final Map<String, List<String>> dbAccessTypeMapping;
+    private final Set<String> privilegedUsers;
+    private final Set<String> serviceUsers;
+    private RangerRMSMappingRefresher mappingRefresher;
+
+    protected RangerRMSChainedPlugin(RangerBasePlugin rootPlugin, String serviceType, String serviceName) {
+        super(rootPlugin, serviceType, serviceName);
+
+        this.mappingCache = new RangerRMSMappingCache(rootPlugin.getServiceName());
+
+        RangerPluginConfig config = rootPlugin.getPluginContext().getConfig();
+        String propertyPrefix = config.getPropertyPrefix();
+
+        this.authorizeOnlyWithChainedPlugin = config.getBoolean(
+            propertyPrefix + ".mapping.hive.authorize.with.only.chained.policies", true);
+
+        this.accessTypeMapping = loadAccessTypeMapping(config, propertyPrefix, false);
+        this.dbAccessTypeMapping = loadAccessTypeMapping(config, propertyPrefix, true);
+
+        this.privilegedUsers = loadUserSet(config, propertyPrefix + ".privileged.user.names",
+            "admin,dpprofiler,hue,beacon,hive,impala");
+        this.serviceUsers = loadUserSet(config, propertyPrefix + ".service.names",
+            "hive,impala");
+
+        LOG.info("RangerRMSChainedPlugin: authorizeOnlyWithChainedPlugin={}", authorizeOnlyWithChainedPlugin);
+    }
+
+    private Map<String, List<String>> loadAccessTypeMapping(RangerPluginConfig config, String prefix, boolean isDbLevel) {
+        Map<String, List<String>> ret = new HashMap<>();
+
+        String mappingPrefix = prefix + (isDbLevel ? ".db.accesstype.mapping." : ".accesstype.mapping.");
+
+        String readMapping = config.get(mappingPrefix + "read", HIVE_ACCESS_TYPE_SELECT);
+        String writeMapping = config.get(mappingPrefix + "write", HIVE_ACCESS_TYPE_UPDATE + "," + HIVE_ACCESS_TYPE_ALTER);
+        String executeMapping = config.get(mappingPrefix + "execute", HIVE_ACCESS_TYPE_ANY);
+
+        ret.put(STORAGE_ACCESS_TYPE_READ, parseAccessTypes(readMapping));
+        ret.put(STORAGE_ACCESS_TYPE_WRITE, parseAccessTypes(writeMapping));
+        ret.put(STORAGE_ACCESS_TYPE_EXECUTE, parseAccessTypes(executeMapping));
+
+        // Ozone/S3 extended access types
+        String listMapping = config.get(mappingPrefix + "list", HIVE_ACCESS_TYPE_SELECT);
+        String createMapping = config.get(mappingPrefix + "create", HIVE_ACCESS_TYPE_CREATE);
+        String deleteMapping = config.get(mappingPrefix + "delete", HIVE_ACCESS_TYPE_DROP);
+        String readAclMapping = config.get(mappingPrefix + "read_acl", HIVE_ACCESS_TYPE_SELECT);
+        String writeAclMapping = config.get(mappingPrefix + "write_acl", HIVE_ACCESS_TYPE_UPDATE);
+
+        ret.put(STORAGE_ACCESS_TYPE_LIST, parseAccessTypes(listMapping));
+        ret.put(STORAGE_ACCESS_TYPE_CREATE, parseAccessTypes(createMapping));
+        ret.put(STORAGE_ACCESS_TYPE_DELETE, parseAccessTypes(deleteMapping));
+        ret.put(STORAGE_ACCESS_TYPE_READ_ACL, parseAccessTypes(readAclMapping));
+        ret.put(STORAGE_ACCESS_TYPE_WRITE_ACL, parseAccessTypes(writeAclMapping));
+
+        if (isDbLevel) {
+            ret.put(STORAGE_ACCESS_TYPE_READ, parseAccessTypes(config.get(mappingPrefix + "read", HIVE_ACCESS_TYPE_ANY)));
+            ret.put(STORAGE_ACCESS_TYPE_WRITE, parseAccessTypes(config.get(mappingPrefix + "write",
+                HIVE_ACCESS_TYPE_CREATE + "," + HIVE_ACCESS_TYPE_DROP + "," + HIVE_ACCESS_TYPE_ALTER)));
+        }
+
+        return ret;
+    }
+
+    private List<String> parseAccessTypes(String accessTypes) {
+        List<String> ret = new ArrayList<>();
+        if (StringUtils.isNotBlank(accessTypes)) {
+            for (String accessType : accessTypes.split(",")) {
+                if (StringUtils.isNotBlank(accessType)) {
+                    ret.add(accessType.trim());
+                }
+            }
+        }
+        return ret;
+    }
+
+    private Set<String> loadUserSet(RangerPluginConfig config, String property, String defaultValue) {
+        Set<String> ret = new HashSet<>();
+        String value = config.get(property, defaultValue);
+        if (StringUtils.isNotBlank(value)) {
+            for (String user : value.split(",")) {
+                if (StringUtils.isNotBlank(user)) {
+                    ret.add(user.trim().toLowerCase());
+                }
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    protected RangerBasePlugin buildChainedPlugin(String serviceType, String serviceName, String appId) {
+        RangerPluginConfig rootConfig = rootPlugin.getPluginContext().getConfig();
+        RangerChainedPluginConfig chainedConfig = new RangerChainedPluginConfig(serviceType, serviceName, appId, rootConfig);
+        return new RangerBasePlugin(chainedConfig);
+    }
+
+    @Override
+    public void init() {
+        LOG.info("==> RangerRMSChainedPlugin.init(serviceType={}, serviceName={})", serviceType, serviceName);
+
+        super.init();
+
+        try {
+            RangerAdminClient adminClient = RangerBasePlugin.createAdminClient(
+                plugin.getPluginContext().getConfig());
+            RangerPluginConfig config = rootPlugin.getPluginContext().getConfig();
+
+            // Defensive: if init() is called more than once on the same instance
+            // (e.g. plugin re-init on policy failover), stop the previous refresher
+            // before allocating a new one so the old daemon thread does not leak.
+            if (mappingRefresher != null) {
+                LOG.warn("RangerRMSChainedPlugin.init invoked while a previous mappingRefresher exists; stopping it first");
+                mappingRefresher.stopRefresher();
+                mappingRefresher = null;
+            }
+
+            mappingRefresher = new RangerRMSMappingRefresher(
+                this,
+                rootPlugin.getServiceName(),
+                serviceName,
+                adminClient,
+                config
+            );
+
+            mappingRefresher.startRefresher();
+            LOG.info("RMS Mapping Refresher started for service: {}", rootPlugin.getServiceName());
+        } catch (Exception e) {
+            LOG.error("Failed to start RMS Mapping Refresher", e);
+        }
+
+        LOG.info("<== RangerRMSChainedPlugin.init()");
+    }
+
+    /**
+     * Stop the periodic mapping refresher when the underlying plugin is torn
+     * down. {@link RangerChainedPlugin} does not declare a cleanup() hook (it
+     * is not a {@link RangerBasePlugin} subclass), so this is a new public API
+     * that callers responsible for plugin lifecycle (e.g. NameNode RMS plugin
+     * shutdown / re-init) should invoke. Without it, a re-init / failover
+     * would leak the daemon thread created by
+     * {@link RangerRMSMappingRefresher#startRefresher()} for every cycle,
+     * accumulating threads that continue to hit Ranger Admin.
+     */
+    public void cleanup() {
+        LOG.info("==> RangerRMSChainedPlugin.cleanup(serviceName={})", rootPlugin.getServiceName());
+
+        try {
+            RangerRMSMappingRefresher toStop = mappingRefresher;
+            mappingRefresher = null;
+            if (toStop != null) {
+                toStop.stopRefresher();
+            }
+        } catch (Exception e) {
+            LOG.error("Error stopping RMS Mapping Refresher during cleanup", e);
+        }
+
+        // Symmetric to init() (which calls plugin.init() via super.init()): release the
+        // inner RangerBasePlugin's policy refresher and engine state.
+        try {
+            if (plugin != null) {
+                plugin.cleanup();
+            }
+        } catch (Exception e) {
+            LOG.error("Error during inner plugin cleanup", e);
+        }
+
+        LOG.info("<== RangerRMSChainedPlugin.cleanup()");
+    }
+
+    @Override
+    public RangerAccessResult isAccessAllowed(RangerAccessRequest request) {
+        LOG.debug("==> RangerRMSChainedPlugin.isAccessAllowed({})", request);
+
+        RangerAccessResult ret = null;
+
+        if (request == null) {
+            LOG.debug("<== RangerRMSChainedPlugin.isAccessAllowed(): null request");
+            return null;
+        }
+
+        if (isPrivilegedUser(request.getUser())) {
+            LOG.debug("Skipping chained evaluation for privileged user: {}", request.getUser());
+            return null;
+        }
+
+        if (skipAccessCheckIfAlreadyDetermined && isAccessDetermined(request)) {
+            LOG.debug("Skipping chained evaluation as access is already determined");
+            return null;
+        }
+
+        String storagePath = extractStoragePath(request);
+        if (StringUtils.isBlank(storagePath)) {
+            LOG.debug("No storage path found in request");
+            return null;
+        }
+
+        MappingEntry mapping = mappingCache.findMappingForPath(storagePath);
+        if (mapping == null) {
+            LOG.debug("No RMS mapping found for path: {}", storagePath);
+            return authorizeOnlyWithChainedPlugin ? createDeniedResult(request) : null;
+        }
+
+        ret = evaluateHiveAccess(request, mapping);
+
+        LOG.debug("<== RangerRMSChainedPlugin.isAccessAllowed(): result={}", ret);
+        return ret;
+    }
+
+    @Override
+    public Collection<RangerAccessResult> isAccessAllowed(Collection<RangerAccessRequest> requests) {
+        List<RangerAccessResult> ret = new ArrayList<>();
+
+        if (CollectionUtils.isNotEmpty(requests)) {
+            for (RangerAccessRequest request : requests) {
+                RangerAccessResult result = isAccessAllowed(request);
+                ret.add(result);
+            }
+        }
+
+        return ret;
+    }
+
+    @Override
+    public RangerResourceACLs getResourceACLs(RangerAccessRequest request) {
+        return getResourceACLs(request, null);
+    }
+
+    @Override
+    public RangerResourceACLs getResourceACLs(RangerAccessRequest request, Integer policyType) {
+        LOG.debug("==> RangerRMSChainedPlugin.getResourceACLs()");
+
+        RangerResourceACLs ret = null;
+
+        if (request != null) {
+            String storagePath = extractStoragePath(request);
+            MappingEntry mapping = storagePath != null ? mappingCache.findMappingForPath(storagePath) : null;
+
+            if (mapping != null) {
+                RangerAccessRequestImpl hiveRequest = createHiveRequest(request, mapping);
+                if (hiveRequest != null && plugin != null) {
+                    ret = plugin.getResourceACLs(hiveRequest, policyType);
+                }
+            }
+        }
+
+        LOG.debug("<== RangerRMSChainedPlugin.getResourceACLs(): {}", ret);
+        return ret;
+    }
+
+    @Override
+    public boolean isAuthorizeOnlyWithChainedPlugin() {
+        return authorizeOnlyWithChainedPlugin;
+    }
+
+    @Override
+    public RangerAccessResult evalDataMaskPolicies(RangerAccessRequest request) {
+        LOG.debug("==> RangerRMSChainedPlugin.evalDataMaskPolicies()");
+
+        RangerAccessResult ret = null;
+
+        String storagePath = extractStoragePath(request);
+        MappingEntry mapping = storagePath != null ? mappingCache.findMappingForPath(storagePath) : null;
+
+        if (mapping != null) {
+            RangerAccessRequestImpl hiveRequest = createHiveRequest(request, mapping);
+            if (hiveRequest != null && plugin != null) {
+                ret = plugin.evalDataMaskPolicies(hiveRequest, null);
+            }
+        }
+
+        LOG.debug("<== RangerRMSChainedPlugin.evalDataMaskPolicies(): {}", ret);
+        return ret;
+    }
+
+    @Override
+    public RangerAccessResult evalRowFilterPolicies(RangerAccessRequest request) {
+        LOG.debug("==> RangerRMSChainedPlugin.evalRowFilterPolicies()");
+
+        RangerAccessResult ret = null;
+
+        String storagePath = extractStoragePath(request);
+        MappingEntry mapping = storagePath != null ? mappingCache.findMappingForPath(storagePath) : null;
+
+        if (mapping != null) {
+            RangerAccessRequestImpl hiveRequest = createHiveRequest(request, mapping);
+            if (hiveRequest != null && plugin != null) {
+                ret = plugin.evalRowFilterPolicies(hiveRequest, null);
+            }
+        }
+
+        LOG.debug("<== RangerRMSChainedPlugin.evalRowFilterPolicies(): {}", ret);
+        return ret;
+    }
+
+    /**
+     * Update the mapping cache with new mappings.
+     */
+    public void updateMappings(ServiceRMSMappings rmsMappings) {
+        if (rmsMappings != null) {
+            mappingCache.update(rmsMappings);
+        }
+    }
+
+    /**
+     * Get the current mapping version.
+     */
+    public Long getMappingVersion() {
+        return mappingCache.getMappingVersion();
+    }
+
+    /**
+     * Extract storage path from the request. Override in subclasses for specific resource types.
+     */
+    protected abstract String extractStoragePath(RangerAccessRequest request);
+
+    /**
+     * Check if a user is privileged (should skip RMS evaluation).
+     */
+    protected boolean isPrivilegedUser(String user) {
+        if (StringUtils.isBlank(user)) {
+            return false;
+        }
+        return privilegedUsers.contains(user.toLowerCase()) || serviceUsers.contains(user.toLowerCase());
+    }
+
+    /**
+     * Check if access is already determined.
+     */
+    protected boolean isAccessDetermined(RangerAccessRequest request) {
+        Object isAccessDetermined = request.getContext() != null ?
+            request.getContext().get("isAccessDetermined") : null;
+        return Boolean.TRUE.equals(isAccessDetermined);
+    }
+
+    /**
+     * Evaluate Hive access for a storage request.
+     */
+    protected RangerAccessResult evaluateHiveAccess(RangerAccessRequest request, MappingEntry mapping) {
+        LOG.debug("==> evaluateHiveAccess(user={}, database={}, table={})",
+                  request.getUser(), mapping.getHiveDatabaseName(), mapping.getHiveTableName());
+
+        RangerAccessResult ret = null;
+
+        RangerAccessResult maskResult = evalDataMaskPolicies(request);
+        if (maskResult != null && maskResult.isMaskEnabled()) {
+            LOG.info("Denying access due to masking policy on table: {}.{}",
+                     mapping.getHiveDatabaseName(), mapping.getHiveTableName());
+            ret = createDeniedResult(request);
+            ret.setReason("Masking policy exists for the mapped Hive resource");
+            return ret;
+        }
+
+        RangerAccessResult rowFilterResult = evalRowFilterPolicies(request);
+        if (rowFilterResult != null && rowFilterResult.isRowFilterEnabled()) {
+            LOG.info("Denying access due to row-filter policy on table: {}.{}",
+                     mapping.getHiveDatabaseName(), mapping.getHiveTableName());
+            ret = createDeniedResult(request);
+            ret.setReason("Row-filter policy exists for the mapped Hive resource");
+            return ret;
+        }
+
+        List<String> hiveAccessTypes = mapStorageAccessToHive(request.getAccessType(),
+            StringUtils.isBlank(mapping.getHiveTableName()));
+
+        if (CollectionUtils.isEmpty(hiveAccessTypes)) {
+            return null;
+        }
+
+        for (String hiveAccessType : hiveAccessTypes) {
+            RangerAccessRequestImpl hiveRequest = createHiveRequest(request, mapping);
+            if (hiveRequest != null) {
+                hiveRequest.setAccessType(hiveAccessType);
+
+                if (plugin != null) {
+                    RangerAccessResult hiveResult = plugin.isAccessAllowed(hiveRequest);
+                    if (hiveResult != null && hiveResult.getIsAllowed()) {
+                        ret = hiveResult;
+                        break;
+                    } else if (hiveResult != null && hiveResult.getIsAccessDetermined()) {
+                        ret = hiveResult;
+                    }
+                }
+            }
+        }
+
+        if (ret == null && authorizeOnlyWithChainedPlugin) {
+            ret = createDeniedResult(request);
+        }
+
+        LOG.debug("<== evaluateHiveAccess(): isAllowed={}", ret != null ? ret.getIsAllowed() : null);
+        return ret;
+    }
+
+    /**
+     * Create a Hive access request from a storage request.
+     */
+    protected RangerAccessRequestImpl createHiveRequest(RangerAccessRequest storageRequest, MappingEntry mapping) {
+        RangerAccessResourceImpl hiveResource = new RangerAccessResourceImpl();
+        hiveResource.setServiceDef(plugin.getServiceDef());
+        hiveResource.setValue("database", mapping.getHiveDatabaseName());
+
+        String tableName = mapping.getHiveTableName();
+        if (StringUtils.isNotBlank(tableName)) {
+            hiveResource.setValue("table", tableName);
+            hiveResource.setValue("column", "*");
+        }
+
+        RangerAccessRequestImpl ret = new RangerAccessRequestImpl();
+        ret.setResource(hiveResource);
+        ret.setUser(storageRequest.getUser());
+        ret.setUserGroups(storageRequest.getUserGroups());
+        ret.setUserRoles(storageRequest.getUserRoles());
+        ret.setAccessType(storageRequest.getAccessType());
+        ret.setAction(storageRequest.getAction());
+        ret.setClientIPAddress(storageRequest.getClientIPAddress());
+        ret.setClientType(storageRequest.getClientType());
+        ret.setAccessTime(storageRequest.getAccessTime());
+        ret.setClusterName(storageRequest.getClusterName());
+
+        return ret;
+    }
+
+    /**
+     * Map storage access type to Hive access types.
+     */
+    protected List<String> mapStorageAccessToHive(String storageAccessType, boolean isDatabaseLevel) {
+        Map<String, List<String>> mapping = isDatabaseLevel ? dbAccessTypeMapping : accessTypeMapping;
+        List<String> ret = mapping.get(storageAccessType);
+        return ret != null ? ret : new ArrayList<>();
+    }
+
+    /**
+     * Create a denied access result.
+     */
+    protected RangerAccessResult createDeniedResult(RangerAccessRequest request) {
+        RangerAccessResult ret = new RangerAccessResult(
+            RangerPolicy.POLICY_TYPE_ACCESS, serviceName, plugin.getServiceDef(), request);
+        ret.setIsAllowed(false);
+        ret.setIsAccessDetermined(true);
+        return ret;
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerRMSChainedPlugin.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/service/RangerRMSChainedPlugin.java
@@ -384,6 +384,18 @@ public abstract class RangerRMSChainedPlugin extends RangerChainedPlugin {
     }
 
     /**
+     * Accessor for the underlying mapping cache. Used by
+     * {@link org.apache.ranger.plugin.util.RangerRMSMappingRefresher} to
+     * snapshot the cumulative cache state into a {@link ServiceRMSMappings}
+     * before persisting to the on-disk policycache JSON, so a delta payload
+     * doesn't overwrite the cumulative state on disk and cause data loss
+     * across plugin restarts.
+     */
+    public RangerRMSMappingCache getMappingCache() {
+        return mappingCache;
+    }
+
+    /**
      * Extract storage path from the request. Override in subclasses for specific resource types.
      */
     protected abstract String extractStoragePath(RangerAccessRequest request);

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingCache.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingCache.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.model.RangerServiceResource;
+import org.apache.ranger.plugin.util.ServiceRMSMappings.RMSResourceMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * RangerRMSMappingCache caches RMS mappings and provides lookup functionality.
+ * Used by chained plugins to map storage resources (HDFS paths, S3 keys, Ozone keys)
+ * to Hive resources (databases, tables).
+ */
+public class RangerRMSMappingCache {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerRMSMappingCache.class);
+
+    private final String serviceName;
+    private final String hlServiceName;
+    private volatile Long mappingVersion;
+
+    private static class CacheSnapshot {
+        final Map<String, RangerServiceResource> resourcesByGuid;
+        final Map<String, List<MappingEntry>> mappingsByLlPath;
+        final Map<String, MappingEntry> mappingsByHlResource;
+
+        CacheSnapshot() {
+            this.resourcesByGuid = Collections.emptyMap();
+            this.mappingsByLlPath = Collections.emptyMap();
+            this.mappingsByHlResource = Collections.emptyMap();
+        }
+
+        CacheSnapshot(Map<String, RangerServiceResource> resourcesByGuid,
+                       Map<String, List<MappingEntry>> mappingsByLlPath,
+                       Map<String, MappingEntry> mappingsByHlResource) {
+            this.resourcesByGuid = Collections.unmodifiableMap(resourcesByGuid);
+            this.mappingsByLlPath = Collections.unmodifiableMap(mappingsByLlPath);
+            this.mappingsByHlResource = Collections.unmodifiableMap(mappingsByHlResource);
+        }
+    }
+
+    private final AtomicReference<CacheSnapshot> snapshot = new AtomicReference<>(new CacheSnapshot());
+
+    public RangerRMSMappingCache(String serviceName) {
+        this.serviceName = serviceName;
+        this.hlServiceName = null;
+        this.mappingVersion = 0L;
+    }
+
+    /**
+     * Update the cache atomically with new mappings (copy-on-write).
+     * Supports both full replacement (isDelta=false) and incremental merge (isDelta=true).
+     *
+     * Writer-side serialization: the periodic {@link RangerRMSMappingRefresher}
+     * already single-flights via an AtomicBoolean, but {@link #update} is also
+     * reachable from {@code loadFromCache()} during plugin init and from any
+     * other future caller. Synchronize the writer path on {@code this} so a
+     * delta can never read a snapshot that another delta is mid-replacing and
+     * lose merged state. Readers ({@link #findMappingForPath}, etc.) remain
+     * lock-free via {@code AtomicReference.get()}.
+     */
+    public synchronized void update(ServiceRMSMappings rmsMappings) {
+        if (rmsMappings == null) {
+            return;
+        }
+
+        if (Boolean.TRUE.equals(rmsMappings.getIsDelta())) {
+            applyDelta(rmsMappings);
+        } else {
+            applyFull(rmsMappings);
+        }
+    }
+
+    private void applyFull(ServiceRMSMappings rmsMappings) {
+        LOG.debug("==> applyFull(mappingVersion={})", rmsMappings.getMappingVersion());
+
+        Map<String, RangerServiceResource> newResources = new HashMap<>();
+        Map<String, List<MappingEntry>> newPathMappings = new HashMap<>();
+        Map<String, MappingEntry> newHlMappings = new HashMap<>();
+
+        if (MapUtils.isNotEmpty(rmsMappings.getServiceResources())) {
+            newResources.putAll(rmsMappings.getServiceResources());
+        }
+
+        if (CollectionUtils.isNotEmpty(rmsMappings.getResourceMappings())) {
+            for (RMSResourceMapping mapping : rmsMappings.getResourceMappings()) {
+                processMapping(mapping, newResources, newPathMappings, newHlMappings);
+            }
+        }
+
+        snapshot.set(new CacheSnapshot(newResources, newPathMappings, newHlMappings));
+        this.mappingVersion = rmsMappings.getMappingVersion() != null ? rmsMappings.getMappingVersion() : 0L;
+
+        LOG.info("RangerRMSMappingCache full update: resourceCount={}, mappingCount={}, version={}",
+                 newResources.size(), newPathMappings.size(), mappingVersion);
+    }
+
+    private void applyDelta(ServiceRMSMappings rmsMappings) {
+        LOG.debug("==> applyDelta(mappingVersion={})", rmsMappings.getMappingVersion());
+
+        CacheSnapshot current = snapshot.get();
+
+        Map<String, RangerServiceResource> mergedResources = new HashMap<>(current.resourcesByGuid);
+        Map<String, List<MappingEntry>> mergedPathMappings = new HashMap<>();
+        Map<String, MappingEntry> mergedHlMappings = new HashMap<>(current.mappingsByHlResource);
+
+        for (Map.Entry<String, List<MappingEntry>> entry : current.mappingsByLlPath.entrySet()) {
+            mergedPathMappings.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+        }
+
+        // Remove deleted resources
+        List<String> removedGuids = rmsMappings.getRemovedResourceGuids();
+        if (CollectionUtils.isNotEmpty(removedGuids)) {
+            Set<String> removedGuidSet = new HashSet<>(removedGuids);
+            for (String removedGuid : removedGuids) {
+                RangerServiceResource removedResource = mergedResources.remove(removedGuid);
+                if (removedResource == null) {
+                    continue;
+                }
+                String path = extractPath(removedResource);
+                if (StringUtils.isBlank(path)) {
+                    continue;
+                }
+                String normalizedPath = normalizePathForLookup(path);
+                List<MappingEntry> pathEntries = mergedPathMappings.get(normalizedPath);
+                if (CollectionUtils.isEmpty(pathEntries)) {
+                    continue;
+                }
+                // The cache supports multiple MappingEntry values per LL path
+                // (one Hive table can map to a path, and multiple Hive tables
+                // can share the same path). Only drop entries whose LL resource
+                // matches the removed GUID; leave any other entries that share
+                // this path intact.
+                pathEntries.removeIf(mappingEntry ->
+                    mappingEntry.getLlResource() != null
+                        && StringUtils.equals(mappingEntry.getLlResource().getGuid(), removedGuid));
+                if (pathEntries.isEmpty()) {
+                    mergedPathMappings.remove(normalizedPath);
+                }
+            }
+            // Clean up HL mappings that reference removed LL resources
+            mergedHlMappings.entrySet().removeIf(e ->
+                e.getValue() != null
+                    && e.getValue().getLlResource() != null
+                    && removedGuidSet.contains(e.getValue().getLlResource().getGuid()));
+        }
+
+        // Add new/updated resources and mappings
+        if (MapUtils.isNotEmpty(rmsMappings.getServiceResources())) {
+            mergedResources.putAll(rmsMappings.getServiceResources());
+        }
+
+        if (CollectionUtils.isNotEmpty(rmsMappings.getResourceMappings())) {
+            for (RMSResourceMapping mapping : rmsMappings.getResourceMappings()) {
+                processMapping(mapping, mergedResources, mergedPathMappings, mergedHlMappings);
+            }
+        }
+
+        snapshot.set(new CacheSnapshot(mergedResources, mergedPathMappings, mergedHlMappings));
+        this.mappingVersion = rmsMappings.getMappingVersion() != null ? rmsMappings.getMappingVersion() : 0L;
+
+        int addCount = rmsMappings.getResourceMappings() != null ? rmsMappings.getResourceMappings().size() : 0;
+        int removeCount = removedGuids != null ? removedGuids.size() : 0;
+
+        LOG.info("RangerRMSMappingCache delta update: +{} added, -{} removed, total mappings={}, version={}",
+                 addCount, removeCount, mergedPathMappings.size(), mappingVersion);
+    }
+
+    private void processMapping(RMSResourceMapping mapping,
+                                 Map<String, RangerServiceResource> resources,
+                                 Map<String, List<MappingEntry>> pathMappings,
+                                 Map<String, MappingEntry> hlMappings) {
+        if (mapping == null) {
+            return;
+        }
+
+        String hlGuid = mapping.getHlResourceGuid();
+        String llGuid = mapping.getLlResourceGuid();
+
+        if (StringUtils.isBlank(hlGuid) || StringUtils.isBlank(llGuid)) {
+            return;
+        }
+
+        RangerServiceResource hlResource = resources.get(hlGuid);
+        RangerServiceResource llResource = resources.get(llGuid);
+
+        if (hlResource == null || llResource == null) {
+            return;
+        }
+
+        String llPath = extractPath(llResource);
+        if (StringUtils.isBlank(llPath)) {
+            return;
+        }
+
+        MappingEntry entry = new MappingEntry(hlResource, llResource, mapping);
+
+        pathMappings.computeIfAbsent(normalizePathForLookup(llPath), k -> new ArrayList<>()).add(entry);
+
+        String hlKey = buildHlResourceKey(hlResource);
+        if (StringUtils.isNotBlank(hlKey)) {
+            hlMappings.put(hlKey, entry);
+        }
+    }
+
+    /**
+     * Find the Hive resource mapping for a storage path.
+     */
+    public MappingEntry findMappingForPath(String path) {
+        if (StringUtils.isBlank(path)) {
+            return null;
+        }
+
+        LOG.debug("==> findMappingForPath({})", path);
+
+        CacheSnapshot current = snapshot.get();
+        String normalizedPath = normalizePathForLookup(path);
+        MappingEntry ret = null;
+
+        List<MappingEntry> exactMatches = current.mappingsByLlPath.get(normalizedPath);
+        if (CollectionUtils.isNotEmpty(exactMatches)) {
+            ret = exactMatches.get(0);
+        }
+
+        if (ret == null) {
+            ret = findMappingForParentPath(normalizedPath, current);
+        }
+
+        LOG.debug("<== findMappingForPath({}): found={}", path, ret != null);
+        return ret;
+    }
+
+    private MappingEntry findMappingForParentPath(String path, CacheSnapshot current) {
+        if (StringUtils.isBlank(path)) {
+            return null;
+        }
+
+        String parentPath = getParentPath(path);
+        while (StringUtils.isNotBlank(parentPath)) {
+            List<MappingEntry> matches = current.mappingsByLlPath.get(parentPath);
+            if (CollectionUtils.isNotEmpty(matches)) {
+                for (MappingEntry entry : matches) {
+                    if (entry.isRecursive()) {
+                        return entry;
+                    }
+                }
+            }
+            parentPath = getParentPath(parentPath);
+        }
+
+        return null;
+    }
+
+    private String getParentPath(String path) {
+        if (StringUtils.isBlank(path) || "/".equals(path)) {
+            return null;
+        }
+
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return "/";
+        }
+
+        return path.substring(0, lastSlash);
+    }
+
+    /**
+     * Find Hive resource by database and table name.
+     */
+    public MappingEntry findMappingForHiveResource(String databaseName, String tableName) {
+        if (StringUtils.isBlank(databaseName)) {
+            return null;
+        }
+
+        String key = buildHlResourceKey(databaseName, tableName);
+        return snapshot.get().mappingsByHlResource.get(key);
+    }
+
+    /**
+     * Extract storage path from a resource.
+     */
+    private String extractPath(RangerServiceResource resource) {
+        if (resource == null || MapUtils.isEmpty(resource.getResourceElements())) {
+            return null;
+        }
+
+        Map<String, RangerPolicy.RangerPolicyResource> elements = resource.getResourceElements();
+
+        // HDFS / Hive path resource. Capture the value list reference once so a
+        // concurrent mutation of the underlying List between an isNotEmpty() check
+        // and a get(0) call cannot trigger an IndexOutOfBoundsException.
+        String pathValue = firstValueOf(elements.get("path"));
+        if (pathValue != null) {
+            return pathValue;
+        }
+
+        String keyValue = firstValueOf(elements.get("key"));
+        if (keyValue != null) {
+            StringBuilder sb = new StringBuilder();
+
+            String volumeValue = firstValueOf(elements.get("volume"));
+            String bucketValue = firstValueOf(elements.get("bucket"));
+
+            if (volumeValue != null) {
+                sb.append("/").append(volumeValue);
+            }
+            if (bucketValue != null) {
+                sb.append("/").append(bucketValue);
+            }
+            sb.append("/").append(keyValue);
+
+            return sb.toString();
+        }
+
+        // S3-style: path or object element, optionally prefixed by bucket.
+        String s3PathValue = firstValueOf(elements.get("object"));
+        if (s3PathValue != null) {
+            String bucketValue = firstValueOf(elements.get("bucket"));
+            StringBuilder sb = new StringBuilder();
+            if (bucketValue != null) {
+                sb.append(bucketValue).append("/");
+            }
+            sb.append(s3PathValue);
+            return sb.toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the first non-blank value of a {@link RangerPolicy.RangerPolicyResource},
+     * or {@code null} if the resource is null/empty. Snapshots the value list reference
+     * so callers cannot observe a "non-empty then empty" race between two getValues() calls.
+     */
+    private static String firstValueOf(RangerPolicy.RangerPolicyResource policyResource) {
+        if (policyResource == null) {
+            return null;
+        }
+        List<String> values = policyResource.getValues();
+        if (CollectionUtils.isEmpty(values)) {
+            return null;
+        }
+        return values.get(0);
+    }
+
+    /**
+     * Normalize a path for lookup.
+     */
+    private String normalizePathForLookup(String path) {
+        if (StringUtils.isBlank(path)) {
+            return path;
+        }
+
+        String normalized = path;
+
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+
+        while (normalized.endsWith("/") && normalized.length() > 1) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+
+        return normalized;
+    }
+
+    /**
+     * Build a key for HL resource lookup.
+     */
+    private String buildHlResourceKey(RangerServiceResource resource) {
+        if (resource == null || MapUtils.isEmpty(resource.getResourceElements())) {
+            return null;
+        }
+
+        Map<String, RangerPolicy.RangerPolicyResource> elements = resource.getResourceElements();
+
+        return buildHlResourceKey(firstValueOf(elements.get("database")),
+                                  firstValueOf(elements.get("table")));
+    }
+
+    private String buildHlResourceKey(String database, String table) {
+        if (StringUtils.isBlank(database)) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(database.toLowerCase());
+
+        if (StringUtils.isNotBlank(table)) {
+            sb.append(".").append(table.toLowerCase());
+        }
+
+        return sb.toString();
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getHlServiceName() {
+        return hlServiceName;
+    }
+
+    public Long getMappingVersion() {
+        return mappingVersion;
+    }
+
+    public int getMappingCount() {
+        return snapshot.get().mappingsByLlPath.size();
+    }
+
+    /**
+     * Mapping entry containing both HL and LL resources.
+     */
+    public static class MappingEntry {
+        private final RangerServiceResource hlResource;
+        private final RangerServiceResource llResource;
+        private final RMSResourceMapping mapping;
+
+        public MappingEntry(RangerServiceResource hlResource, RangerServiceResource llResource, RMSResourceMapping mapping) {
+            this.hlResource = hlResource;
+            this.llResource = llResource;
+            this.mapping = mapping;
+        }
+
+        public RangerServiceResource getHlResource() {
+            return hlResource;
+        }
+
+        public RangerServiceResource getLlResource() {
+            return llResource;
+        }
+
+        public RMSResourceMapping getMapping() {
+            return mapping;
+        }
+
+        public String getHiveDatabaseName() {
+            return getResourceValue(hlResource, "database");
+        }
+
+        public String getHiveTableName() {
+            return getResourceValue(hlResource, "table");
+        }
+
+        public boolean isRecursive() {
+            if (llResource == null || MapUtils.isEmpty(llResource.getResourceElements())) {
+                return false;
+            }
+
+            for (RangerPolicy.RangerPolicyResource resource : llResource.getResourceElements().values()) {
+                if (resource != null && Boolean.TRUE.equals(resource.getIsRecursive())) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private String getResourceValue(RangerServiceResource resource, String key) {
+            if (resource == null || MapUtils.isEmpty(resource.getResourceElements())) {
+                return null;
+            }
+            return firstValueOf(resource.getResourceElements().get(key));
+        }
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingCache.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingCache.java
@@ -440,6 +440,50 @@ public class RangerRMSMappingCache {
     }
 
     /**
+     * Snapshot the current in-memory cache state as a {@link ServiceRMSMappings}
+     * suitable for persisting to the on-disk policycache JSON.
+     *
+     * Why this exists: the plugin-side refresher persists the wire payload it
+     * just received -- but that payload may be a delta that contains only the
+     * newly-added mappings. Writing the raw delta to disk loses cumulative
+     * state, so a NameNode restart that then reads the cache JSON would see
+     * only the most recent delta's worth of mappings (correct mappingVersion,
+     * but a sparse resourceMappings list) and `lastKnownVersion` would already
+     * equal the server's current version -- meaning the plugin would never
+     * re-download the full set until a watermark fallback forces it.
+     *
+     * Persisting the cumulative snapshot built here keeps load-from-cache
+     * restart-safe and consistent with the developer-guide §3 lifecycle
+     * contract ("Plugin restart: policycache JSON on disk survives").
+     */
+    public ServiceRMSMappings toServiceRMSMappings() {
+        CacheSnapshot snap = snapshot.get();
+        if (snap == null) {
+            return null;
+        }
+
+        ServiceRMSMappings ret = new ServiceRMSMappings(serviceName, hlServiceName, mappingVersion);
+        ret.setIsDelta(false);
+        ret.setLastKnownVersion(mappingVersion);
+
+        if (snap.resourcesByGuid != null && !snap.resourcesByGuid.isEmpty()) {
+            ret.setServiceResources(new HashMap<>(snap.resourcesByGuid));
+        }
+
+        if (snap.mappingsByHlResource != null && !snap.mappingsByHlResource.isEmpty()) {
+            List<RMSResourceMapping> mappings = new ArrayList<>(snap.mappingsByHlResource.size());
+            for (MappingEntry entry : snap.mappingsByHlResource.values()) {
+                if (entry != null && entry.getMapping() != null) {
+                    mappings.add(entry.getMapping());
+                }
+            }
+            ret.setResourceMappings(mappings);
+        }
+
+        return ret;
+    }
+
+    /**
      * Mapping entry containing both HL and LL resources.
      */
     public static class MappingEntry {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.authorization.hadoop.config.RangerPluginConfig;
+import org.apache.ranger.plugin.service.RangerRMSChainedPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * RangerRMSMappingRefresher periodically downloads resource mappings from RMS
+ * and updates the chained plugin's mapping cache.
+ *
+ * Configuration properties:
+ * - ranger.plugin.{service}.mapping.source.download.interval: Download interval in milliseconds (default: 30000)
+ * - ranger.plugin.{service}.mapping.source.url: RMS URL (if different from Ranger Admin)
+ * - ranger.plugin.{service}.mapping.cache.dir: Directory to cache mappings locally
+ */
+public class RangerRMSMappingRefresher implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerRMSMappingRefresher.class);
+    private static final Logger PERF_LOG = RangerPerfTracer.getPerfLogger("rms.mapping.refresh");
+
+    private static final String MAPPING_FILE_SUFFIX = "_resource_mapping.json";
+    private static final long DEFAULT_DOWNLOAD_INTERVAL_MS = 30000;
+    private static final long MIN_DOWNLOAD_INTERVAL_MS = 10000;
+
+    private final RangerRMSChainedPlugin chainedPlugin;
+    private final String serviceName;
+    private final String hlServiceName;
+    private final RangerAdminClient adminClient;
+    private final long downloadIntervalMs;
+    private final String cacheDir;
+    private final String cacheFile;
+    private final Gson gson;
+
+    private volatile Long lastKnownVersion;
+    private volatile long lastDownloadTimeMs;
+    private ScheduledExecutorService scheduler;
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+
+    public RangerRMSMappingRefresher(RangerRMSChainedPlugin chainedPlugin,
+                                      String serviceName,
+                                      String hlServiceName,
+                                      RangerAdminClient adminClient,
+                                      RangerPluginConfig config) {
+        this.chainedPlugin = chainedPlugin;
+        this.serviceName = serviceName;
+        this.hlServiceName = hlServiceName;
+        this.adminClient = adminClient;
+
+        String propertyPrefix = config.getPropertyPrefix();
+        this.downloadIntervalMs = Math.max(MIN_DOWNLOAD_INTERVAL_MS,
+            config.getLong(propertyPrefix + ".mapping.source.download.interval", DEFAULT_DOWNLOAD_INTERVAL_MS));
+
+        String defaultCacheDir = config.get(propertyPrefix + ".policy.cache.dir",
+            "/etc/ranger/" + serviceName + "/policycache");
+        this.cacheDir = config.get(propertyPrefix + ".mapping.cache.dir", defaultCacheDir);
+
+        this.cacheFile = cacheDir + File.separator + serviceName + "_" + hlServiceName + MAPPING_FILE_SUFFIX;
+
+        this.gson = new GsonBuilder().setPrettyPrinting().create();
+
+        LOG.info("RangerRMSMappingRefresher created: serviceName={}, hlServiceName={}, downloadIntervalMs={}, cacheFile={}",
+                 serviceName, hlServiceName, downloadIntervalMs, cacheFile);
+    }
+
+    /**
+     * Start the periodic refresh task. Safe to call once per refresher
+     * instance; subsequent calls are ignored to prevent leaking a second
+     * scheduler on accidental double-init.
+     */
+    public synchronized void startRefresher() {
+        LOG.info("==> RangerRMSMappingRefresher.startRefresher()");
+
+        if (scheduler != null && !scheduler.isShutdown()) {
+            LOG.warn("RangerRMSMappingRefresher already started for serviceName={}; ignoring duplicate start", serviceName);
+            return;
+        }
+
+        loadFromCache();
+
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "RMS-Mapping-Refresher-" + serviceName);
+            t.setDaemon(true);
+            return t;
+        });
+
+        scheduler.scheduleAtFixedRate(this, 0, downloadIntervalMs, TimeUnit.MILLISECONDS);
+
+        LOG.info("<== RangerRMSMappingRefresher.startRefresher()");
+    }
+
+    /**
+     * Stop the periodic refresh task. Idempotent: safe to call multiple times
+     * (e.g. from a chained-plugin cleanup() override that may itself be invoked
+     * more than once during plugin re-init / failover).
+     */
+    public synchronized void stopRefresher() {
+        LOG.info("==> RangerRMSMappingRefresher.stopRefresher()");
+
+        ScheduledExecutorService toStop = scheduler;
+        scheduler = null;
+
+        if (toStop != null && !toStop.isShutdown()) {
+            toStop.shutdown();
+            try {
+                if (!toStop.awaitTermination(30, TimeUnit.SECONDS)) {
+                    toStop.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                toStop.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        LOG.info("<== RangerRMSMappingRefresher.stopRefresher()");
+    }
+
+    @Override
+    public void run() {
+        if (!isRunning.compareAndSet(false, true)) {
+            LOG.debug("Skipping refresh - previous refresh still in progress");
+            return;
+        }
+
+        try {
+            downloadMappings();
+        } catch (Exception e) {
+            LOG.error("Error during RMS mapping refresh", e);
+        } finally {
+            isRunning.set(false);
+        }
+    }
+
+    /**
+     * Download mappings from RMS.
+     * Passes lastKnownVersion so the server can return 304 (no changes)
+     * or a full/delta response. Only updates cache when version changes.
+     */
+    private void downloadMappings() {
+        LOG.debug("==> downloadMappings(serviceName={}, lastKnownVersion={})", serviceName, lastKnownVersion);
+
+        RangerPerfTracer perf = null;
+        if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+            perf = RangerPerfTracer.getPerfTracer(PERF_LOG,
+                "RangerRMSMappingRefresher.downloadMappings(serviceName=" + serviceName + ")");
+        }
+
+        try {
+            ServiceRMSMappings mappings = fetchMappingsFromRMS();
+
+            if (mappings == null) {
+                LOG.debug("No mappings returned (304 Not Modified or null): serviceName={}", serviceName);
+            } else {
+                Long newVersion = mappings.getMappingVersion();
+
+                if (newVersion != null && !newVersion.equals(lastKnownVersion)) {
+                    LOG.info("New mappings received: serviceName={}, version={} -> {}, isDelta={}",
+                             serviceName, lastKnownVersion, newVersion, mappings.getIsDelta());
+
+                    chainedPlugin.updateMappings(mappings);
+                    saveToCache(mappings);
+
+                    this.lastKnownVersion = newVersion;
+                } else {
+                    LOG.debug("No mapping changes: serviceName={}, version={}", serviceName, lastKnownVersion);
+                }
+            }
+
+            this.lastDownloadTimeMs = System.currentTimeMillis();
+
+        } catch (Exception e) {
+            LOG.error("Failed to download RMS mappings for service: {}", serviceName, e);
+        } finally {
+            RangerPerfTracer.log(perf);
+        }
+
+        LOG.debug("<== downloadMappings()");
+    }
+
+    /**
+     * Fetch mappings from RMS server.
+     */
+    private ServiceRMSMappings fetchMappingsFromRMS() {
+        LOG.debug("==> fetchMappingsFromRMS(serviceName={}, lastKnownVersion={})", serviceName, lastKnownVersion);
+
+        ServiceRMSMappings ret = null;
+
+        try {
+            ret = adminClient.getRMSMappings(serviceName, lastKnownVersion);
+        } catch (Exception e) {
+            LOG.error("Error fetching RMS mappings from server", e);
+        }
+
+        LOG.debug("<== fetchMappingsFromRMS(): {}", ret);
+        return ret;
+    }
+
+    /**
+     * Load mappings from local cache file.
+     */
+    private void loadFromCache() {
+        LOG.debug("==> loadFromCache(cacheFile={})", cacheFile);
+
+        RangerPerfTracer perf = null;
+        if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+            perf = RangerPerfTracer.getPerfTracer(PERF_LOG,
+                "RangerRMSMappingRefresher.loadFromCache(cacheFile=" + cacheFile + ")");
+        }
+
+        try {
+            File file = new File(cacheFile);
+            if (file.exists() && file.canRead()) {
+                try (Reader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
+                    ServiceRMSMappings mappings = gson.fromJson(reader, ServiceRMSMappings.class);
+
+                    if (mappings != null) {
+                        chainedPlugin.updateMappings(mappings);
+                        this.lastKnownVersion = mappings.getMappingVersion();
+                        LOG.info("Loaded RMS mappings from cache: version={}", lastKnownVersion);
+                    }
+                }
+            } else {
+                LOG.debug("Cache file does not exist or is not readable: {}", cacheFile);
+            }
+        } catch (Exception e) {
+            LOG.error("Error loading RMS mappings from cache", e);
+        } finally {
+            RangerPerfTracer.log(perf);
+        }
+
+        LOG.debug("<== loadFromCache()");
+    }
+
+    /**
+     * Save mappings to local cache file.
+     */
+    private void saveToCache(ServiceRMSMappings mappings) {
+        LOG.debug("==> saveToCache(cacheFile={})", cacheFile);
+
+        RangerPerfTracer perf = null;
+        if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+            perf = RangerPerfTracer.getPerfTracer(PERF_LOG,
+                "RangerRMSMappingRefresher.saveToCache(cacheFile=" + cacheFile + ")");
+        }
+
+        try {
+            File cacheDirectory = new File(cacheDir);
+            if (!cacheDirectory.exists()) {
+                if (!cacheDirectory.mkdirs()) {
+                    LOG.error("Failed to create cache directory: {}", cacheDir);
+                    return;
+                }
+            }
+
+            File tmpFile = new File(cacheFile + ".tmp");
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {
+                gson.toJson(mappings, writer);
+            }
+
+            File targetFile = new File(cacheFile);
+            if (targetFile.exists()) {
+                targetFile.delete();
+            }
+            if (!tmpFile.renameTo(targetFile)) {
+                LOG.error("Failed to rename tmp cache file {} to {}", tmpFile.getAbsolutePath(), targetFile.getAbsolutePath());
+            } else {
+                LOG.info("Saved RMS mappings to cache: version={}", mappings.getMappingVersion());
+            }
+        } catch (Exception e) {
+            LOG.error("Error saving RMS mappings to cache", e);
+        } finally {
+            RangerPerfTracer.log(perf);
+        }
+
+        LOG.debug("<== saveToCache()");
+    }
+
+    public Long getLastKnownVersion() {
+        return lastKnownVersion;
+    }
+
+    public long getLastDownloadTimeMs() {
+        return lastDownloadTimeMs;
+    }
+
+    public String getCacheFile() {
+        return cacheFile;
+    }
+}

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
@@ -193,7 +193,21 @@ public class RangerRMSMappingRefresher implements Runnable {
                              serviceName, lastKnownVersion, newVersion, mappings.getIsDelta());
 
                     chainedPlugin.updateMappings(mappings);
-                    saveToCache(mappings);
+
+                    // Persist the cumulative cache state, not the raw wire payload.
+                    // The payload may be a delta (only newly-added mappings); writing
+                    // it directly would cause a NameNode restart to load only those
+                    // delta-shaped mappings -- with lastKnownVersion already equal
+                    // to the server's currentVersion, the server would then return
+                    // 304 / no-change and the plugin would permanently miss the
+                    // cumulative state until a watermark fallback forced a full
+                    // re-download. Snapshot from the cache instead so the on-disk
+                    // file is always a complete picture of what's authoritative
+                    // for this service.
+                    ServiceRMSMappings snapshot = chainedPlugin.getMappingCache() != null
+                            ? chainedPlugin.getMappingCache().toServiceRMSMappings()
+                            : null;
+                    saveToCache(snapshot != null ? snapshot : mappings);
 
                     this.lastKnownVersion = newVersion;
                 } else {

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/RangerRMSMappingRefresher.java
@@ -159,8 +159,14 @@ public class RangerRMSMappingRefresher implements Runnable {
 
         try {
             downloadMappings();
-        } catch (Exception e) {
-            LOG.error("Error during RMS mapping refresh", e);
+        } catch (Throwable t) {
+            // Catching Throwable (not just Exception) because this Runnable is
+            // handed to scheduleAtFixedRate; per the executor contract, if the
+            // task escapes with an uncaught Throwable all future runs are
+            // suppressed. An Error from a native/JNI path or an OutOfMemoryError
+            // during a large download would otherwise silently stop the
+            // refresher until the plugin JVM restarts.
+            LOG.error("Error during RMS mapping refresh", t);
         } finally {
             isRunning.set(false);
         }

--- a/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceRMSMappings.java
+++ b/agents-common/src/main/java/org/apache/ranger/plugin/util/ServiceRMSMappings.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.plugin.util;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.model.RangerServiceResource;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ServiceRMSMappings contains the resource mappings for a service.
+ * This is used by plugins to download Hive-to-Storage mappings from RMS.
+ */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ServiceRMSMappings implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String                        serviceName;
+    private String                        hlServiceName;
+    private Long                          mappingVersion;
+    private Long                          lastKnownVersion;
+    private Boolean                       isDelta;
+    private List<String>                  removedResourceGuids;
+    private List<RMSResourceMapping>      resourceMappings;
+    private Map<String, RangerServiceResource> serviceResources;
+
+    public ServiceRMSMappings() {
+        this.resourceMappings = new ArrayList<>();
+        this.serviceResources = new HashMap<>();
+    }
+
+    public ServiceRMSMappings(String serviceName, String hlServiceName, Long mappingVersion) {
+        this();
+        this.serviceName = serviceName;
+        this.hlServiceName = hlServiceName;
+        this.mappingVersion = mappingVersion;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getHlServiceName() {
+        return hlServiceName;
+    }
+
+    public void setHlServiceName(String hlServiceName) {
+        this.hlServiceName = hlServiceName;
+    }
+
+    public Long getMappingVersion() {
+        return mappingVersion;
+    }
+
+    public void setMappingVersion(Long mappingVersion) {
+        this.mappingVersion = mappingVersion;
+    }
+
+    public Long getLastKnownVersion() {
+        return lastKnownVersion;
+    }
+
+    public void setLastKnownVersion(Long lastKnownVersion) {
+        this.lastKnownVersion = lastKnownVersion;
+    }
+
+    public Boolean getIsDelta() {
+        return isDelta;
+    }
+
+    public void setIsDelta(Boolean isDelta) {
+        this.isDelta = isDelta;
+    }
+
+    public List<String> getRemovedResourceGuids() {
+        return removedResourceGuids;
+    }
+
+    public void setRemovedResourceGuids(List<String> removedResourceGuids) {
+        this.removedResourceGuids = removedResourceGuids;
+    }
+
+    public void addRemovedResourceGuid(String guid) {
+        if (this.removedResourceGuids == null) {
+            this.removedResourceGuids = new ArrayList<>();
+        }
+        this.removedResourceGuids.add(guid);
+    }
+
+    public List<RMSResourceMapping> getResourceMappings() {
+        return resourceMappings;
+    }
+
+    public void setResourceMappings(List<RMSResourceMapping> resourceMappings) {
+        this.resourceMappings = resourceMappings;
+    }
+
+    public Map<String, RangerServiceResource> getServiceResources() {
+        return serviceResources;
+    }
+
+    public void setServiceResources(Map<String, RangerServiceResource> serviceResources) {
+        this.serviceResources = serviceResources;
+    }
+
+    public void addResourceMapping(RMSResourceMapping mapping) {
+        if (this.resourceMappings == null) {
+            this.resourceMappings = new ArrayList<>();
+        }
+        this.resourceMappings.add(mapping);
+    }
+
+    public void addServiceResource(RangerServiceResource resource) {
+        if (this.serviceResources == null) {
+            this.serviceResources = new HashMap<>();
+        }
+        if (resource.getGuid() != null) {
+            this.serviceResources.put(resource.getGuid(), resource);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ServiceRMSMappings={");
+        sb.append("serviceName=").append(serviceName);
+        sb.append(", hlServiceName=").append(hlServiceName);
+        sb.append(", mappingVersion=").append(mappingVersion);
+        sb.append(", lastKnownVersion=").append(lastKnownVersion);
+        sb.append(", resourceMappingsCount=").append(resourceMappings != null ? resourceMappings.size() : 0);
+        sb.append(", serviceResourcesCount=").append(serviceResources != null ? serviceResources.size() : 0);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * RMSResourceMapping represents a single mapping between HL resource (Hive) and LL resource (Storage).
+     */
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RMSResourceMapping implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private String hlResourceGuid;
+        private String llResourceGuid;
+        private Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements;
+        private Map<String, RangerPolicy.RangerPolicyResource> llResourceElements;
+
+        public RMSResourceMapping() {
+        }
+
+        public RMSResourceMapping(String hlResourceGuid, String llResourceGuid,
+                                  Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements,
+                                  Map<String, RangerPolicy.RangerPolicyResource> llResourceElements) {
+            this.hlResourceGuid = hlResourceGuid;
+            this.llResourceGuid = llResourceGuid;
+            this.hlResourceElements = hlResourceElements;
+            this.llResourceElements = llResourceElements;
+        }
+
+        public String getHlResourceGuid() {
+            return hlResourceGuid;
+        }
+
+        public void setHlResourceGuid(String hlResourceGuid) {
+            this.hlResourceGuid = hlResourceGuid;
+        }
+
+        public String getLlResourceGuid() {
+            return llResourceGuid;
+        }
+
+        public void setLlResourceGuid(String llResourceGuid) {
+            this.llResourceGuid = llResourceGuid;
+        }
+
+        public Map<String, RangerPolicy.RangerPolicyResource> getHlResourceElements() {
+            return hlResourceElements;
+        }
+
+        public void setHlResourceElements(Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements) {
+            this.hlResourceElements = hlResourceElements;
+        }
+
+        public Map<String, RangerPolicy.RangerPolicyResource> getLlResourceElements() {
+            return llResourceElements;
+        }
+
+        public void setLlResourceElements(Map<String, RangerPolicy.RangerPolicyResource> llResourceElements) {
+            this.llResourceElements = llResourceElements;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("RMSResourceMapping={");
+            sb.append("hlResourceGuid=").append(hlResourceGuid);
+            sb.append(", llResourceGuid=").append(llResourceGuid);
+            sb.append(", hlResourceElements=").append(hlResourceElements);
+            sb.append(", llResourceElements=").append(llResourceElements);
+            sb.append("}");
+            return sb.toString();
+        }
+    }
+}

--- a/agents-common/src/main/resources/rms-default.xml
+++ b/agents-common/src/main/resources/rms-default.xml
@@ -1,0 +1,284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  Ranger RMS (Resource Mapping Server) Configuration
+  
+  RMS enables automatic synchronization of Hive policies to storage layer
+  (HDFS, Ozone, S3), eliminating the need to maintain separate policies.
+-->
+<configuration>
+
+    <!-- ==================== RMS Server Configuration ==================== -->
+    
+    <!-- Enable/disable RMS (Resource Mapping Server) -->
+    <property>
+        <name>ranger.rms.enabled</name>
+        <value>false</value>
+        <description>Enable RMS to sync Hive policies to storage (HDFS/Ozone/S3)</description>
+    </property>
+    
+    <!-- HMS Thrift URI for direct polling -->
+    <property>
+        <name>ranger.rms.hms.uri</name>
+        <value></value>
+        <description>HMS Thrift URI (e.g., thrift://hms-host:9083). If empty, uses hive-site.xml defaults.</description>
+    </property>
+    
+    <!-- HMS polling interval in milliseconds -->
+    <property>
+        <name>ranger.rms.polling.notifications.frequency.ms</name>
+        <value>30000</value>
+        <description>Interval for polling HMS notifications (default: 30 seconds)</description>
+    </property>
+    
+    <!-- Perform initial full sync on startup -->
+    <property>
+        <name>ranger.rms.initial.full.sync</name>
+        <value>true</value>
+        <description>Perform full sync from HMS on RMS startup</description>
+    </property>
+    
+    <!-- Hive service name in Ranger (target service) -->
+    <property>
+        <name>ranger.rms.hive.service.name</name>
+        <value>hive</value>
+        <description>Name of the Hive service in Ranger</description>
+    </property>
+    
+    <!-- HDFS service name in Ranger (source service for HDFS) -->
+    <property>
+        <name>ranger.rms.hdfs.service.name</name>
+        <value>hdfs</value>
+        <description>Name of the HDFS service in Ranger</description>
+    </property>
+    
+    <!-- Ozone service name in Ranger -->
+    <property>
+        <name>ranger.rms.ozone.service.name</name>
+        <value>ozone</value>
+        <description>Name of the Ozone service in Ranger</description>
+    </property>
+    
+    <!-- S3 service name in Ranger (source service for S3/RAZ) -->
+    <property>
+        <name>ranger.rms.s3.service.name</name>
+        <value>s3</value>
+        <description>Name of the S3 service in Ranger</description>
+    </property>
+    
+    <!-- Supported URI schemes -->
+    <property>
+        <name>ranger.rms.supported.uri.schemes</name>
+        <value>hdfs,o3fs,ofs,s3a</value>
+        <description>Comma-separated list of supported URI schemes</description>
+    </property>
+    
+    <!-- Whether to track managed tables (external tables are always tracked) -->
+    <property>
+        <name>ranger.rms.map.managed.tables</name>
+        <value>true</value>
+        <description>Track managed Hive tables. Default: true</description>
+    </property>
+    
+    <!-- ==================== HMS Security Configuration ==================== -->
+    
+    <!-- Enable SASL/Kerberos authentication to HMS -->
+    <property>
+        <name>ranger.rms.hms.sasl.enabled</name>
+        <value>false</value>
+        <description>Enable SASL (Kerberos GSSAPI) authentication when connecting to HMS.
+            Set to true when hive.metastore.sasl.enabled=true on the HMS side.</description>
+    </property>
+    
+    <!-- Kerberos principal of the HMS server -->
+    <property>
+        <name>ranger.rms.hms.kerberos.principal</name>
+        <value></value>
+        <description>Kerberos service principal for HMS (e.g., hive/_HOST@REALM).
+            _HOST is auto-replaced with the HMS hostname at connection time.</description>
+    </property>
+    
+    <!-- Enable SSL/TLS for HMS connection -->
+    <property>
+        <name>ranger.rms.hms.ssl.enabled</name>
+        <value>false</value>
+        <description>Use SSL/TLS transport when connecting to HMS.</description>
+    </property>
+    
+    <!-- SSL truststore path -->
+    <property>
+        <name>ranger.rms.hms.ssl.truststore.path</name>
+        <value></value>
+        <description>Path to the Java truststore for HMS SSL (JKS format).</description>
+    </property>
+    
+    <!-- SSL truststore password -->
+    <property>
+        <name>ranger.rms.hms.ssl.truststore.password</name>
+        <value></value>
+        <description>Password for the HMS SSL truststore.</description>
+    </property>
+    
+    <!-- ==================== HDFS Plugin Configuration ==================== -->
+    
+    <!-- Enable Hive-HDFS chained plugin (replace {hive_service_name} with your Ranger Hive service name) -->
+    <property>
+        <name>ranger.plugin.hdfs.chained.services</name>
+        <value>{hive_service_name}</value>
+        <description>Comma-separated list of chained services for HDFS</description>
+    </property>
+    
+    <!-- Chained plugin implementation class -->
+    <property>
+        <name>ranger.plugin.hdfs.chained.services.{hive_service_name}.impl</name>
+        <value>org.apache.ranger.chainedplugin.hdfs.hive.RangerHdfsHiveChainedPlugin</value>
+        <description>Implementation class for HDFS-Hive chained plugin</description>
+    </property>
+    
+    <!-- Enforce strict Sentry semantics (deny if no Hive policy) -->
+    <property>
+        <name>ranger.plugin.hdfs.mapping.hive.authorize.with.only.chained.policies</name>
+        <value>true</value>
+        <description>If true, deny access when no applicable Hive policy exists</description>
+    </property>
+    
+    <!-- HDFS to Hive access type mappings -->
+    <property>
+        <name>ranger.plugin.hdfs.accesstype.mapping.read</name>
+        <value>select</value>
+        <description>Hive access types for HDFS read</description>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.hdfs.accesstype.mapping.write</name>
+        <value>update,alter</value>
+        <description>Hive access types for HDFS write</description>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.hdfs.accesstype.mapping.execute</name>
+        <value>_any</value>
+        <description>Hive access types for HDFS execute</description>
+    </property>
+    
+    <!-- Mapping download interval -->
+    <property>
+        <name>ranger.plugin.hdfs.mapping.source.download.interval</name>
+        <value>30000</value>
+        <description>Interval for downloading mappings from RMS (ms)</description>
+    </property>
+    
+    <!-- ==================== Ozone Plugin Configuration ==================== -->
+    
+    <!-- Enable Hive-Ozone chained plugin (replace {hive_service_name} with your Ranger Hive service name) -->
+    <property>
+        <name>ranger.plugin.ozone.chained.services</name>
+        <value>{hive_service_name}</value>
+        <description>Comma-separated list of chained services for Ozone</description>
+    </property>
+    
+    <!-- Chained plugin implementation class -->
+    <property>
+        <name>ranger.plugin.ozone.chained.services.{hive_service_name}.impl</name>
+        <value>org.apache.ranger.chainedplugin.ozone.hive.RangerOzoneHiveChainedPlugin</value>
+        <description>Implementation class for Ozone-Hive chained plugin</description>
+    </property>
+    
+    <!-- Ozone to Hive access type mappings (for tables) -->
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.read</name>
+        <value>select</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.write</name>
+        <value>update</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.create</name>
+        <value>create</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.delete</name>
+        <value>drop</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.list</name>
+        <value>select</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.read_acl</name>
+        <value>select</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.accesstype.mapping.write_acl</name>
+        <value>update</value>
+    </property>
+    
+    <!-- Ozone to Hive access type mappings (for databases) -->
+    <property>
+        <name>ranger.plugin.ozone.db.accesstype.mapping.read</name>
+        <value>_any</value>
+    </property>
+    
+    <property>
+        <name>ranger.plugin.ozone.db.accesstype.mapping.write</name>
+        <value>update</value>
+    </property>
+    
+    <!-- ==================== S3-Hive Chained Plugin Configuration ==================== -->
+
+    <!-- Enable Hive-S3 chained plugin (replace {hive_service_name} with your Ranger Hive service name) -->
+    <property>
+        <name>ranger.plugin.s3.chained.services</name>
+        <value>{hive_service_name}</value>
+        <description>Comma-separated list of chained services for S3</description>
+    </property>
+
+    <!-- Chained plugin implementation class -->
+    <property>
+        <name>ranger.plugin.s3.chained.services.{hive_service_name}.impl</name>
+        <value>org.apache.ranger.chainedplugin.s3.hive.RangerS3HiveChainedPlugin</value>
+        <description>Implementation class for S3-Hive chained plugin</description>
+    </property>
+
+    <!-- S3 to Hive access type mappings -->
+    <property>
+        <name>ranger.plugin.s3.accesstype.mapping.read</name>
+        <value>select</value>
+    </property>
+
+    <property>
+        <name>ranger.plugin.s3.accesstype.mapping.write</name>
+        <value>update,alter</value>
+    </property>
+
+    <!-- Privileged users (skip RMS evaluation) -->
+    <property>
+        <name>ranger.plugin.s3.privileged.user.names</name>
+        <value>admin,dpprofiler,hue,beacon,hive,impala</value>
+        <description>Users with full access (skip Hive policy check)</description>
+    </property>
+
+</configuration>

--- a/hive-agent/src/main/java/org/apache/ranger/authorization/hive/metastore/RangerRMSMetaStoreEventListener.java
+++ b/hive-agent/src/main/java/org/apache/ranger/authorization/hive/metastore/RangerRMSMetaStoreEventListener.java
@@ -1,0 +1,469 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.authorization.hive.metastore;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.MetaStoreEventListener;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.events.AlterDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.AlterTableEvent;
+import org.apache.hadoop.hive.metastore.events.CreateDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.CreateTableEvent;
+import org.apache.hadoop.hive.metastore.events.DropDatabaseEvent;
+import org.apache.hadoop.hive.metastore.events.DropTableEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RangerRMSMetaStoreEventListener is an OPTIONAL push-based Hive Metastore
+ * event listener that sends notifications to a Ranger RMS notification
+ * endpoint when tables and databases are created, modified, or deleted.
+ *
+ * NOTE: The default RMS deployment uses the pull-based
+ * {@code RangerRMSPollerService} on Ranger Admin to poll HMS via Thrift.
+ * This listener is an alternative push-based mechanism that requires a
+ * compatible Admin-side notification REST endpoint (matching
+ * {@code ranger.rms.notification.url}) to be deployed; the standard
+ * Ranger Admin RMS REST surface does NOT expose such an endpoint by
+ * default. As a result this listener is disabled by default and must
+ * be explicitly enabled (and pointed at a custom endpoint) by operators
+ * who choose the push model.
+ *
+ * Configuration properties (in hive-site.xml):
+ * - ranger.rms.notification.enabled: Enable/disable notifications
+ *   Default: false (must be explicitly enabled)
+ * - ranger.rms.notification.url: URL of the custom RMS notification endpoint
+ *   No safe default — must be set when enabled
+ * - ranger.rms.notification.username / password: HTTP basic auth credentials
+ *   No safe default — must be set when enabled
+ * - ranger.rms.hive.service.name: Name of Hive service in Ranger (default: hive)
+ * - ranger.rms.notification.ssl.verify: Verify SSL certificates (default: true)
+ *
+ * To enable, add to hive-site.xml:
+ * <property>
+ *   <name>hive.metastore.event.listeners</name>
+ *   <value>org.apache.ranger.authorization.hive.metastore.RangerRMSMetaStoreEventListener</value>
+ * </property>
+ * <property>
+ *   <name>ranger.rms.notification.enabled</name>
+ *   <value>true</value>
+ * </property>
+ * <property>
+ *   <name>ranger.rms.notification.url</name>
+ *   <value>https://your-admin-host:6182/service/rms/notification</value>
+ * </property>
+ */
+public class RangerRMSMetaStoreEventListener extends MetaStoreEventListener {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerRMSMetaStoreEventListener.class);
+
+    private static final String CONFIG_RMS_URL = "ranger.rms.notification.url";
+    private static final String CONFIG_RMS_USERNAME = "ranger.rms.notification.username";
+    private static final String CONFIG_RMS_PASSWORD = "ranger.rms.notification.password";
+    private static final String CONFIG_HIVE_SERVICE_NAME = "ranger.rms.hive.service.name";
+    private static final String CONFIG_NOTIFICATION_ENABLED = "ranger.rms.notification.enabled";
+    private static final String CONFIG_SSL_VERIFY = "ranger.rms.notification.ssl.verify";
+
+    // No safe default for the URL/credentials — operators must configure them
+    // when opting into the listener. The listener is disabled by default
+    // (see CONFIG_NOTIFICATION_ENABLED handling below).
+    private static final String DEFAULT_RMS_URL = "";
+    private static final String DEFAULT_USERNAME = "";
+    private static final String DEFAULT_PASSWORD = "";
+    private static final String DEFAULT_HIVE_SERVICE_NAME = "hive";
+
+    private static final String CHANGE_TYPE_CREATE_DATABASE = "CREATE_DATABASE";
+    private static final String CHANGE_TYPE_DROP_DATABASE = "DROP_DATABASE";
+    private static final String CHANGE_TYPE_ALTER_DATABASE = "ALTER_DATABASE";
+    private static final String CHANGE_TYPE_CREATE_TABLE = "CREATE_TABLE";
+    private static final String CHANGE_TYPE_DROP_TABLE = "DROP_TABLE";
+    private static final String CHANGE_TYPE_ALTER_TABLE = "ALTER_TABLE";
+
+    private final String rmsUrl;
+    private final String username;
+    private final String password;
+    private final String hiveServiceName;
+    private final boolean enabled;
+    private final boolean sslVerify;
+    private final ExecutorService executor;
+    private final String authHeader;
+    // Per-listener SSL plumbing used when sslVerify=false. Scoped to the
+    // individual HttpsURLConnections we create here, never installed as
+    // JVM defaults so other HTTPS code in the metastore process is not
+    // affected.
+    private final SSLSocketFactory insecureSocketFactory;
+    private final HostnameVerifier insecureHostnameVerifier;
+
+    public RangerRMSMetaStoreEventListener(Configuration config) {
+        super(config);
+
+        this.rmsUrl = config.get(CONFIG_RMS_URL, DEFAULT_RMS_URL);
+        this.username = config.get(CONFIG_RMS_USERNAME, DEFAULT_USERNAME);
+        this.password = config.get(CONFIG_RMS_PASSWORD, DEFAULT_PASSWORD);
+        this.hiveServiceName = config.get(CONFIG_HIVE_SERVICE_NAME, DEFAULT_HIVE_SERVICE_NAME);
+        // Disabled by default. The push listener requires a custom Admin-side
+        // notification endpoint (not part of the standard RMSREST) and must be
+        // opted into explicitly.
+        boolean explicitlyEnabled = config.getBoolean(CONFIG_NOTIFICATION_ENABLED, false);
+        this.enabled = explicitlyEnabled
+                && !rmsUrl.isEmpty()
+                && !username.isEmpty();
+        if (explicitlyEnabled && !this.enabled) {
+            LOG.warn("RangerRMSMetaStoreEventListener: notifications were enabled "
+                    + "but '{}' or '{}' is not set; staying disabled.",
+                    CONFIG_RMS_URL, CONFIG_RMS_USERNAME);
+        }
+        this.sslVerify = config.getBoolean(CONFIG_SSL_VERIFY, true);
+
+        String credentials = username + ":" + password;
+        this.authHeader = "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+
+        this.executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "RangerRMS-Notification-Sender");
+            t.setDaemon(true);
+            return t;
+        });
+
+        LOG.info("RangerRMSMetaStoreEventListener initialized:");
+        LOG.info("  rmsUrl: {}", rmsUrl);
+        LOG.info("  hiveServiceName: {}", hiveServiceName);
+        LOG.info("  enabled: {}", enabled);
+        LOG.info("  sslVerify: {}", sslVerify);
+
+        if (!sslVerify) {
+            this.insecureSocketFactory = createInsecureSocketFactory();
+            this.insecureHostnameVerifier = (hostname, session) -> true;
+            LOG.warn("SSL verification disabled for RangerRMSMetaStoreEventListener "
+                    + "(scoped to RMS notification connections only). DO NOT USE IN PRODUCTION.");
+        } else {
+            this.insecureSocketFactory = null;
+            this.insecureHostnameVerifier = null;
+        }
+    }
+
+    @Override
+    public void onCreateDatabase(CreateDatabaseEvent dbEvent) throws MetaException {
+        if (!enabled || dbEvent == null || !dbEvent.getStatus()) {
+            return;
+        }
+
+        Database db = dbEvent.getDatabase();
+        if (db == null) {
+            return;
+        }
+
+        LOG.info("onCreateDatabase: {}", db.getName());
+        sendNotificationAsync(CHANGE_TYPE_CREATE_DATABASE, db.getName(), null, db.getLocationUri(), false);
+    }
+
+    @Override
+    public void onDropDatabase(DropDatabaseEvent dbEvent) throws MetaException {
+        if (!enabled || dbEvent == null || !dbEvent.getStatus()) {
+            return;
+        }
+
+        Database db = dbEvent.getDatabase();
+        if (db == null) {
+            return;
+        }
+
+        LOG.info("onDropDatabase: {}", db.getName());
+        sendNotificationAsync(CHANGE_TYPE_DROP_DATABASE, db.getName(), null, db.getLocationUri(), false);
+    }
+
+    @Override
+    public void onAlterDatabase(AlterDatabaseEvent dbEvent) throws MetaException {
+        if (!enabled || dbEvent == null) {
+            return;
+        }
+
+        Database oldDb = dbEvent.getOldDatabase();
+        Database newDb = dbEvent.getNewDatabase();
+
+        if (oldDb == null || newDb == null) {
+            return;
+        }
+
+        String oldLocation = oldDb.getLocationUri();
+        String newLocation = newDb.getLocationUri();
+
+        if (!StringUtils.equals(oldLocation, newLocation)) {
+            LOG.info("onAlterDatabase: {} (location changed: {} -> {})", newDb.getName(), oldLocation, newLocation);
+            sendNotificationAsync(CHANGE_TYPE_ALTER_DATABASE, newDb.getName(), null, newLocation, false);
+        }
+    }
+
+    @Override
+    public void onCreateTable(CreateTableEvent tableEvent) throws MetaException {
+        if (!enabled || tableEvent == null || !tableEvent.getStatus()) {
+            return;
+        }
+
+        Table table = tableEvent.getTable();
+        if (table == null) {
+            return;
+        }
+
+        String location = getTableLocation(table);
+        boolean isManaged = isManaged(table);
+
+        LOG.info("onCreateTable: {}.{} (location={}, isManaged={})", 
+                 table.getDbName(), table.getTableName(), location, isManaged);
+        
+        sendNotificationAsync(CHANGE_TYPE_CREATE_TABLE, table.getDbName(), table.getTableName(), location, isManaged);
+    }
+
+    @Override
+    public void onDropTable(DropTableEvent tableEvent) throws MetaException {
+        if (!enabled || tableEvent == null || !tableEvent.getStatus()) {
+            return;
+        }
+
+        Table table = tableEvent.getTable();
+        if (table == null) {
+            return;
+        }
+
+        String location = getTableLocation(table);
+
+        LOG.info("onDropTable: {}.{} (location={})", table.getDbName(), table.getTableName(), location);
+        sendNotificationAsync(CHANGE_TYPE_DROP_TABLE, table.getDbName(), table.getTableName(), location, false);
+    }
+
+    @Override
+    public void onAlterTable(AlterTableEvent tableEvent) throws MetaException {
+        if (!enabled || tableEvent == null) {
+            return;
+        }
+
+        Table oldTable = tableEvent.getOldTable();
+        Table newTable = tableEvent.getNewTable();
+
+        if (oldTable == null || newTable == null) {
+            return;
+        }
+
+        String oldLocation = getTableLocation(oldTable);
+        String newLocation = getTableLocation(newTable);
+
+        if (!StringUtils.equals(oldLocation, newLocation)) {
+            LOG.info("onAlterTable: {}.{} (location changed: {} -> {})",
+                     newTable.getDbName(), newTable.getTableName(), oldLocation, newLocation);
+            sendNotificationAsync(CHANGE_TYPE_ALTER_TABLE, newTable.getDbName(), newTable.getTableName(), 
+                                  newLocation, isManaged(newTable));
+        }
+    }
+
+    private String getTableLocation(Table table) {
+        if (table != null && table.getSd() != null) {
+            return table.getSd().getLocation();
+        }
+        return null;
+    }
+
+    private boolean isManaged(Table table) {
+        if (table == null) {
+            return false;
+        }
+        String tableType = table.getTableType();
+        return tableType == null || "MANAGED_TABLE".equalsIgnoreCase(tableType);
+    }
+
+    private void sendNotificationAsync(String changeType, String databaseName, String tableName, 
+                                        String location, boolean isManaged) {
+        executor.submit(() -> {
+            try {
+                sendNotification(changeType, databaseName, tableName, location, isManaged);
+            } catch (Exception e) {
+                LOG.error("Failed to send RMS notification: changeType={}, database={}, table={}", 
+                          changeType, databaseName, tableName, e);
+            }
+        });
+    }
+
+    private void sendNotification(String changeType, String databaseName, String tableName, 
+                                   String location, boolean isManaged) {
+        if (StringUtils.isBlank(location)) {
+            LOG.debug("Skipping notification: no location for {}.{}", databaseName, tableName);
+            return;
+        }
+
+        try {
+            String jsonPayload = buildJsonPayload(changeType, databaseName, tableName, location, isManaged);
+            
+            LOG.debug("Sending RMS notification to {}: {}", rmsUrl, jsonPayload);
+
+            URL url = new URL(rmsUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+            // Apply the insecure factory ONLY to this specific connection
+            // when sslVerify=false, instead of mutating JVM-global defaults.
+            if (!sslVerify && conn instanceof HttpsURLConnection) {
+                HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+                if (insecureSocketFactory != null) {
+                    httpsConn.setSSLSocketFactory(insecureSocketFactory);
+                }
+                if (insecureHostnameVerifier != null) {
+                    httpsConn.setHostnameVerifier(insecureHostnameVerifier);
+                }
+            }
+
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", authHeader);
+            conn.setDoOutput(true);
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(10000);
+
+            try (OutputStream os = conn.getOutputStream()) {
+                byte[] input = jsonPayload.getBytes(StandardCharsets.UTF_8);
+                os.write(input, 0, input.length);
+            }
+
+            int responseCode = conn.getResponseCode();
+            
+            if (responseCode >= 200 && responseCode < 300) {
+                LOG.info("RMS notification sent successfully: changeType={}, database={}, table={}, responseCode={}",
+                         changeType, databaseName, tableName, responseCode);
+            } else {
+                String errorResponse = readErrorResponse(conn);
+                LOG.warn("RMS notification failed: changeType={}, database={}, table={}, responseCode={}, response={}",
+                         changeType, databaseName, tableName, responseCode, errorResponse);
+            }
+
+            conn.disconnect();
+
+        } catch (Exception e) {
+            LOG.error("Error sending RMS notification: changeType={}, database={}, table={}",
+                      changeType, databaseName, tableName, e);
+        }
+    }
+
+    private String buildJsonPayload(String changeType, String databaseName, String tableName, 
+                                     String location, boolean isManaged) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        sb.append("\"changeType\":\"").append(escapeJson(changeType)).append("\"");
+        sb.append(",\"serviceName\":\"").append(escapeJson(hiveServiceName)).append("\"");
+        sb.append(",\"databaseName\":\"").append(escapeJson(databaseName)).append("\"");
+        
+        if (StringUtils.isNotBlank(tableName)) {
+            sb.append(",\"tableName\":\"").append(escapeJson(tableName)).append("\"");
+        }
+        
+        if (StringUtils.isNotBlank(location)) {
+            sb.append(",\"location\":\"").append(escapeJson(location)).append("\"");
+        }
+        
+        sb.append(",\"isManaged\":").append(isManaged);
+        sb.append("}");
+        
+        return sb.toString();
+    }
+
+    private String escapeJson(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("\n", "\\n")
+                    .replace("\r", "\\r")
+                    .replace("\t", "\\t");
+    }
+
+    private String readErrorResponse(HttpURLConnection conn) {
+        try {
+            if (conn.getErrorStream() != null) {
+                try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
+                    StringBuilder response = new StringBuilder();
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        response.append(line);
+                    }
+                    return response.toString();
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("Error reading error response", e);
+        }
+        return "";
+    }
+
+    /**
+     * Build a per-listener SSLSocketFactory that trusts all certificates.
+     * This is intentionally local to this listener and applied only to
+     * the HttpsURLConnections we open to the RMS notification URL — it does
+     * NOT mutate JVM-global SSL defaults and therefore does not affect any
+     * other HTTPS code running inside the Hive Metastore process.
+     */
+    private SSLSocketFactory createInsecureSocketFactory() {
+        try {
+            TrustManager[] trustAllCerts = new TrustManager[]{
+                new X509TrustManager() {
+                    public X509Certificate[] getAcceptedIssuers() { return null; }
+                    public void checkClientTrusted(X509Certificate[] certs, String authType) { }
+                    public void checkServerTrusted(X509Certificate[] certs, String authType) { }
+                }
+            };
+
+            SSLContext sc = SSLContext.getInstance("TLS");
+            sc.init(null, trustAllCerts, new java.security.SecureRandom());
+            return sc.getSocketFactory();
+        } catch (Exception e) {
+            LOG.error("Failed to construct insecure SSL socket factory; "
+                    + "SSL verification will remain enabled", e);
+            return null;
+        }
+    }
+
+    public void shutdown() {
+        LOG.info("Shutting down RangerRMSMetaStoreEventListener");
+        executor.shutdown();
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/security-admin/db/mysql/patches/061-rms-add-mapping-version.sql
+++ b/security-admin/db/mysql/patches/061-rms-add-mapping-version.sql
@@ -1,0 +1,34 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add mapping_version column for RMS delta/incremental download support.
+
+DROP PROCEDURE IF EXISTS add_mapping_version_column;
+DELIMITER ;;
+CREATE PROCEDURE add_mapping_version_column()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'x_rms_resource_mapping'
+      AND column_name = 'mapping_version'
+  ) THEN
+    ALTER TABLE x_rms_resource_mapping ADD COLUMN mapping_version bigint(20) DEFAULT 0;
+    CREATE INDEX x_rms_resource_mapping_IDX_mapping_version ON x_rms_resource_mapping(mapping_version);
+  END IF;
+END;;
+DELIMITER ;
+CALL add_mapping_version_column();
+DROP PROCEDURE IF EXISTS add_mapping_version_column;

--- a/security-admin/db/mysql/patches/062-rms-create-deletion-log.sql
+++ b/security-admin/db/mysql/patches/062-rms-create-deletion-log.sql
@@ -1,0 +1,55 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Create persistent RMS deletion log so plugins can be served correct
+-- delta downloads across Admin restarts and HA failovers, and add a
+-- watermark column on x_rms_mapping_provider that records the lowest
+-- mapping_version from which the deletion log is complete.
+
+DROP PROCEDURE IF EXISTS create_rms_deletion_log;
+DELIMITER ;;
+CREATE PROCEDURE create_rms_deletion_log()
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'x_rms_deletion_log'
+  ) THEN
+    CREATE TABLE `x_rms_deletion_log` (
+      `id` bigint(20) NOT NULL AUTO_INCREMENT,
+      `version` bigint(20) NOT NULL,
+      `change_timestamp` timestamp NULL DEFAULT NULL,
+      `hl_resource_guid` varchar(64) DEFAULT NULL,
+      `ll_resource_guid` varchar(64) NOT NULL,
+      `ll_service_id` bigint(20) NOT NULL,
+      PRIMARY KEY (`id`)
+    );
+    CREATE INDEX x_rms_deletion_log_IDX_svc_ver ON x_rms_deletion_log(ll_service_id, version);
+    CREATE INDEX x_rms_deletion_log_IDX_version ON x_rms_deletion_log(version);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'x_rms_mapping_provider'
+      AND column_name = 'deletion_tracking_from_version'
+  ) THEN
+    ALTER TABLE x_rms_mapping_provider
+      ADD COLUMN deletion_tracking_from_version bigint(20) DEFAULT 0;
+  END IF;
+END;;
+DELIMITER ;
+CALL create_rms_deletion_log();
+DROP PROCEDURE IF EXISTS create_rms_deletion_log;

--- a/security-admin/db/oracle/patches/061-rms-add-mapping-version.sql
+++ b/security-admin/db/oracle/patches/061-rms-add-mapping-version.sql
@@ -1,0 +1,28 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add mapping_version column for RMS delta/incremental download support.
+
+DECLARE
+  v_count NUMBER := 0;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM user_tab_columns
+  WHERE table_name = 'X_RMS_RESOURCE_MAPPING' AND column_name = 'MAPPING_VERSION';
+
+  IF v_count = 0 THEN
+    EXECUTE IMMEDIATE 'ALTER TABLE x_rms_resource_mapping ADD mapping_version NUMBER(20) DEFAULT 0';
+    EXECUTE IMMEDIATE 'CREATE INDEX x_rms_resource_mapping_IDX_mapping_version ON x_rms_resource_mapping(mapping_version)';
+  END IF;
+END;/

--- a/security-admin/db/oracle/patches/062-rms-create-deletion-log.sql
+++ b/security-admin/db/oracle/patches/062-rms-create-deletion-log.sql
@@ -1,0 +1,44 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Create persistent RMS deletion log so plugins can be served correct
+-- delta downloads across Admin restarts and HA failovers, and add a
+-- watermark column on x_rms_mapping_provider.
+
+DECLARE
+  v_count NUMBER := 0;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM user_tables WHERE table_name = 'X_RMS_DELETION_LOG';
+  IF v_count = 0 THEN
+    EXECUTE IMMEDIATE 'CREATE TABLE x_rms_deletion_log (
+        id                NUMBER(20) NOT NULL,
+        version           NUMBER(20) NOT NULL,
+        change_timestamp  TIMESTAMP NULL,
+        hl_resource_guid  VARCHAR2(64) NULL,
+        ll_resource_guid  VARCHAR2(64) NOT NULL,
+        ll_service_id     NUMBER(20) NOT NULL,
+        PRIMARY KEY (id))';
+    EXECUTE IMMEDIATE 'CREATE SEQUENCE X_RMS_DELETION_LOG_SEQ START WITH 1 INCREMENT BY 1 NOCACHE NOCYCLE';
+    EXECUTE IMMEDIATE 'CREATE INDEX x_rms_deletion_log_IDX_svc_ver ON x_rms_deletion_log(ll_service_id, version)';
+    EXECUTE IMMEDIATE 'CREATE INDEX x_rms_deletion_log_IDX_version ON x_rms_deletion_log(version)';
+  END IF;
+
+  SELECT COUNT(*) INTO v_count FROM user_tab_columns
+  WHERE table_name = 'X_RMS_MAPPING_PROVIDER' AND column_name = 'DELETION_TRACKING_FROM_VERSION';
+  IF v_count = 0 THEN
+    EXECUTE IMMEDIATE 'ALTER TABLE x_rms_mapping_provider ADD deletion_tracking_from_version NUMBER(20) DEFAULT 0';
+  END IF;
+END;
+/

--- a/security-admin/db/postgres/patches/061-rms-add-mapping-version.sql
+++ b/security-admin/db/postgres/patches/061-rms-add-mapping-version.sql
@@ -1,0 +1,29 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add mapping_version column for RMS delta/incremental download support.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'x_rms_resource_mapping'
+      AND column_name = 'mapping_version'
+  ) THEN
+    ALTER TABLE x_rms_resource_mapping ADD COLUMN mapping_version BIGINT DEFAULT 0;
+    CREATE INDEX x_rms_resource_mapping_IDX_mapping_version ON x_rms_resource_mapping(mapping_version);
+  END IF;
+END
+$$;

--- a/security-admin/db/postgres/patches/062-rms-create-deletion-log.sql
+++ b/security-admin/db/postgres/patches/062-rms-create-deletion-log.sql
@@ -1,0 +1,46 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Create persistent RMS deletion log so plugins can be served correct
+-- delta downloads across Admin restarts and HA failovers, and add a
+-- watermark column on x_rms_mapping_provider.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'x_rms_deletion_log'
+  ) THEN
+    CREATE TABLE x_rms_deletion_log (
+      id                BIGSERIAL PRIMARY KEY,
+      version           BIGINT NOT NULL,
+      change_timestamp  TIMESTAMP NULL,
+      hl_resource_guid  VARCHAR(64) NULL,
+      ll_resource_guid  VARCHAR(64) NOT NULL,
+      ll_service_id     BIGINT NOT NULL
+    );
+    CREATE INDEX x_rms_deletion_log_IDX_svc_ver ON x_rms_deletion_log(ll_service_id, version);
+    CREATE INDEX x_rms_deletion_log_IDX_version ON x_rms_deletion_log(version);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'x_rms_mapping_provider'
+      AND column_name = 'deletion_tracking_from_version'
+  ) THEN
+    ALTER TABLE x_rms_mapping_provider ADD COLUMN deletion_tracking_from_version BIGINT DEFAULT 0;
+  END IF;
+END
+$$;

--- a/security-admin/db/sqlanywhere/patches/061-rms-add-mapping-version.sql
+++ b/security-admin/db/sqlanywhere/patches/061-rms-add-mapping-version.sql
@@ -1,0 +1,29 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add mapping_version column for RMS delta/incremental download support.
+
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM SYS.SYSCOLUMN c
+    JOIN SYS.SYSTABLE t ON c.table_id = t.table_id
+    WHERE t.table_name = 'x_rms_resource_mapping' AND c.column_name = 'mapping_version')
+  THEN
+    ALTER TABLE x_rms_resource_mapping ADD mapping_version BIGINT DEFAULT 0;
+  END IF;
+END;
+GO
+
+CREATE INDEX IF NOT EXISTS x_rms_resource_mapping_IDX_mapping_version ON x_rms_resource_mapping(mapping_version);
+GO

--- a/security-admin/db/sqlanywhere/patches/062-rms-create-deletion-log.sql
+++ b/security-admin/db/sqlanywhere/patches/062-rms-create-deletion-log.sql
@@ -1,0 +1,51 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Create persistent RMS deletion log so plugins can be served correct
+-- delta downloads across Admin restarts and HA failovers, and add a
+-- watermark column on x_rms_mapping_provider.
+
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM SYS.SYSTABLE WHERE table_name = 'x_rms_deletion_log')
+  THEN
+    CREATE TABLE x_rms_deletion_log (
+      id                BIGINT NOT NULL DEFAULT AUTOINCREMENT,
+      version           BIGINT NOT NULL,
+      change_timestamp  TIMESTAMP NULL,
+      hl_resource_guid  VARCHAR(64) NULL,
+      ll_resource_guid  VARCHAR(64) NOT NULL,
+      ll_service_id     BIGINT NOT NULL,
+      PRIMARY KEY (id)
+    );
+  END IF;
+END;
+GO
+
+CREATE INDEX IF NOT EXISTS x_rms_deletion_log_IDX_svc_ver ON x_rms_deletion_log(ll_service_id, version);
+GO
+
+CREATE INDEX IF NOT EXISTS x_rms_deletion_log_IDX_version ON x_rms_deletion_log(version);
+GO
+
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM SYS.SYSCOLUMN c
+    JOIN SYS.SYSTABLE t ON c.table_id = t.table_id
+    WHERE t.table_name = 'x_rms_mapping_provider'
+      AND c.column_name = 'deletion_tracking_from_version')
+  THEN
+    ALTER TABLE x_rms_mapping_provider ADD deletion_tracking_from_version BIGINT DEFAULT 0;
+  END IF;
+END;
+GO

--- a/security-admin/db/sqlserver/patches/061-rms-add-mapping-version.sql
+++ b/security-admin/db/sqlserver/patches/061-rms-add-mapping-version.sql
@@ -1,0 +1,36 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Add mapping_version column for RMS delta/incremental download support.
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns
+  WHERE object_id = OBJECT_ID('x_rms_resource_mapping')
+    AND name = 'mapping_version'
+)
+BEGIN
+  ALTER TABLE [dbo].[x_rms_resource_mapping] ADD [mapping_version] [bigint] DEFAULT 0 NULL
+END
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID('x_rms_resource_mapping')
+    AND name = 'x_rms_resource_mapping_IDX_mapping_version'
+)
+BEGIN
+  CREATE NONCLUSTERED INDEX [x_rms_resource_mapping_IDX_mapping_version] ON [dbo].[x_rms_resource_mapping]([mapping_version] ASC)
+END
+GO

--- a/security-admin/db/sqlserver/patches/061-rms-add-mapping-version.sql
+++ b/security-admin/db/sqlserver/patches/061-rms-add-mapping-version.sql
@@ -25,6 +25,16 @@ BEGIN
 END
 GO
 
+-- SQL Server does NOT backfill existing rows when ADD COLUMN is nullable with
+-- a DEFAULT — the DEFAULT applies only to future inserts, so pre-existing
+-- mappings would remain NULL. That diverges from MySQL/Oracle/Postgres/SQL
+-- Anywhere (which all populate 0 on add) and breaks the delta query on this
+-- column: `WHERE mapping_version > :sinceVersion` with sinceVersion=-1 matches
+-- 0>-1 elsewhere but not NULL>-1 (unknown) here, so SQL Server plugins would
+-- silently miss their baseline mappings on the first delta.
+UPDATE [dbo].[x_rms_resource_mapping] SET [mapping_version] = 0 WHERE [mapping_version] IS NULL
+GO
+
 IF NOT EXISTS (
   SELECT 1 FROM sys.indexes
   WHERE object_id = OBJECT_ID('x_rms_resource_mapping')

--- a/security-admin/db/sqlserver/patches/062-rms-create-deletion-log.sql
+++ b/security-admin/db/sqlserver/patches/062-rms-create-deletion-log.sql
@@ -1,0 +1,64 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Create persistent RMS deletion log so plugins can be served correct
+-- delta downloads across Admin restarts and HA failovers, and add a
+-- watermark column on x_rms_mapping_provider.
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.tables WHERE name = 'x_rms_deletion_log'
+)
+BEGIN
+  CREATE TABLE [dbo].[x_rms_deletion_log] (
+    [id]               [bigint] IDENTITY(1,1) NOT NULL,
+    [version]          [bigint] NOT NULL,
+    [change_timestamp] [datetime2] NULL,
+    [hl_resource_guid] [varchar](64) NULL,
+    [ll_resource_guid] [varchar](64) NOT NULL,
+    [ll_service_id]    [bigint] NOT NULL,
+    PRIMARY KEY CLUSTERED ([id] ASC)
+  )
+END
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID('x_rms_deletion_log')
+    AND name = 'x_rms_deletion_log_IDX_svc_ver'
+)
+BEGIN
+  CREATE NONCLUSTERED INDEX [x_rms_deletion_log_IDX_svc_ver] ON [dbo].[x_rms_deletion_log]([ll_service_id] ASC, [version] ASC)
+END
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.indexes
+  WHERE object_id = OBJECT_ID('x_rms_deletion_log')
+    AND name = 'x_rms_deletion_log_IDX_version'
+)
+BEGIN
+  CREATE NONCLUSTERED INDEX [x_rms_deletion_log_IDX_version] ON [dbo].[x_rms_deletion_log]([version] ASC)
+END
+GO
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.columns
+  WHERE object_id = OBJECT_ID('x_rms_mapping_provider')
+    AND name = 'deletion_tracking_from_version'
+)
+BEGIN
+  ALTER TABLE [dbo].[x_rms_mapping_provider] ADD [deletion_tracking_from_version] [bigint] DEFAULT 0 NULL
+END
+GO

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -30,6 +30,10 @@
         <skipJSTests>false</skipJSTests>
     </properties>
     <dependencies>
+        <!-- RMS HMS polling uses reflection to load Hive Metastore classes.
+             Build with -Prms to bundle them, or manually add to WEB-INF/lib:
+               hive-standalone-metastore-common-{version}.jar
+               libfb303-0.9.3.jar -->
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr-runtime</artifactId>
@@ -1343,4 +1347,33 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>rms</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hive</groupId>
+                    <artifactId>hive-standalone-metastore-common</artifactId>
+                    <version>${hive.version}</version>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.thrift</groupId>
+                    <artifactId>libfb303</artifactId>
+                    <version>0.9.3</version>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/security-admin/src/main/java/org/apache/ranger/biz/RMSMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RMSMgr.java
@@ -1,0 +1,979 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.biz;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.authorization.utils.JsonUtils;
+import org.apache.ranger.common.GUIDUtil;
+import org.apache.ranger.db.RangerDaoManager;
+import org.apache.ranger.db.XXRMSDeletionLogDao;
+import org.apache.ranger.db.XXRMSMappingProviderDao;
+import org.apache.ranger.db.XXRMSNotificationDao;
+import org.apache.ranger.db.XXRMSResourceMappingDao;
+import org.apache.ranger.db.XXRMSServiceResourceDao;
+import org.apache.ranger.db.XXServiceDao;
+import org.apache.ranger.entity.XXRMSDeletionLog;
+import org.apache.ranger.entity.XXRMSMappingProvider;
+import org.apache.ranger.entity.XXRMSNotification;
+import org.apache.ranger.entity.XXRMSResourceMapping;
+import org.apache.ranger.entity.XXRMSServiceResource;
+import org.apache.ranger.entity.XXService;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.model.RangerServiceResource;
+import org.apache.ranger.plugin.util.ServiceRMSMappings;
+import org.apache.ranger.plugin.util.ServiceRMSMappings.RMSResourceMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * RMSMgr handles all Resource Mapping Server (RMS) business logic.
+ * It manages mappings between high-level resources (Hive tables/databases)
+ * and low-level resources (HDFS paths, S3 locations, Ozone keys).
+ */
+@Component
+@Lazy(false)
+public class RMSMgr {
+    private static final Logger LOG = LoggerFactory.getLogger(RMSMgr.class);
+
+    private static final String RMS_MAPPING_PROVIDER_NAME = "HMS";
+    private static final String SERVICE_TYPE_HIVE = "hive";
+    private static final String SERVICE_TYPE_HDFS = "hdfs";
+    private static final String SERVICE_TYPE_OZONE = "ozone";
+    private static final String SERVICE_TYPE_S3 = "s3";
+
+    @Autowired
+    RangerDaoManager daoMgr;
+
+    @Autowired
+    GUIDUtil guidUtil;
+
+    @Autowired
+    ServiceDBStore svcStore;
+
+    private XXRMSMappingProviderDao mappingProviderDao;
+    private XXRMSNotificationDao notificationDao;
+    private XXRMSServiceResourceDao serviceResourceDao;
+    private XXRMSResourceMappingDao resourceMappingDao;
+    private XXRMSDeletionLogDao deletionLogDao;
+    private XXServiceDao serviceDao;
+
+    /**
+     * Process-local memo of fully-built mapping payloads, keyed by service
+     * name and version. When N plugins simultaneously request a full sync at
+     * the same currentVersion (a common pattern after Admin restart, when a
+     * version bump invalidates plugin caches, or when a stale poller falls
+     * below the deletion-tracking watermark), the heavy DB+JSON work runs
+     * exactly once and the rest of the requests reuse the snapshot.
+     *
+     * <p>Bounded size keeps memory predictable in multi-tenant Admins; the
+     * version field embedded in {@link CachedFullMappings} ensures stale
+     * entries can never be served after a mapping write bumps the version.
+     */
+    private static final int FULL_MAPPINGS_CACHE_CAPACITY = 16;
+    private final Map<String, CachedFullMappings> fullMappingsCache =
+            Collections.synchronizedMap(new LinkedHashMap<String, CachedFullMappings>(
+                    FULL_MAPPINGS_CACHE_CAPACITY + 1, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, CachedFullMappings> eldest) {
+                    return size() > FULL_MAPPINGS_CACHE_CAPACITY;
+                }
+            });
+    private final ConcurrentMap<String, Object> fullMappingsBuildLocks = new ConcurrentHashMap<>();
+
+    /**
+     * Immutable snapshot of a fully-built mapping payload for a service.
+     * The collections are populated once by {@link #buildServiceMappings}
+     * and never mutated thereafter, so we can safely share their references
+     * with concurrent JSON-serialization paths in different responses.
+     */
+    private static final class CachedFullMappings {
+        final long                                version;
+        final String                              serviceName;
+        final String                              hlServiceName;
+        final List<RMSResourceMapping>            resourceMappings;
+        final Map<String, RangerServiceResource>  serviceResources;
+
+        CachedFullMappings(ServiceRMSMappings src) {
+            this.version          = src.getMappingVersion() != null ? src.getMappingVersion() : 0L;
+            this.serviceName      = src.getServiceName();
+            this.hlServiceName    = src.getHlServiceName();
+            this.resourceMappings = src.getResourceMappings() != null
+                    ? src.getResourceMappings() : Collections.emptyList();
+            this.serviceResources = src.getServiceResources() != null
+                    ? src.getServiceResources() : Collections.emptyMap();
+        }
+    }
+
+    /**
+     * How many mapping_version slots of deletion history to keep in
+     * {@code x_rms_deletion_log}. At typical DDL rates (10K tables with 1%
+     * delete/day -> ~100 deletions/day) this gives several months of
+     * history at a few KB; at very high churn the table is bounded and
+     * pruning is exercised regularly.
+     */
+    private static final int DELETION_LOG_RETAINED_VERSIONS = 10_000;
+
+    public static class DeletionRecord {
+        public final String hlResourceGuid;
+        public final String llResourceGuid;
+        public final Long   llServiceId;
+
+        public DeletionRecord(String hlResourceGuid, String llResourceGuid, Long llServiceId) {
+            this.hlResourceGuid = hlResourceGuid;
+            this.llResourceGuid = llResourceGuid;
+            this.llServiceId = llServiceId;
+        }
+    }
+
+    @PostConstruct
+    public void init() {
+        LOG.info("==> RMSMgr.init()");
+        mappingProviderDao = daoMgr.getXXRMSMappingProvider();
+        notificationDao = daoMgr.getXXRMSNotification();
+        serviceResourceDao = daoMgr.getXXRMSServiceResource();
+        resourceMappingDao = daoMgr.getXXRMSResourceMapping();
+        deletionLogDao = daoMgr.getXXRMSDeletionLog();
+        serviceDao = daoMgr.getXXService();
+        LOG.info("<== RMSMgr.init()");
+    }
+
+    /**
+     * Get resource mappings for a service (for plugin download).
+     * Supports delta downloads: if lastKnownVersion is provided and valid,
+     * returns only mappings changed since that version (isDelta=true).
+     * If lastKnownVersion is null or 0, returns the full mapping set.
+     */
+    @Transactional(readOnly = true)
+    public ServiceRMSMappings getServiceMappings(String serviceName, Long lastKnownVersion) {
+        LOG.debug("==> RMSMgr.getServiceMappings(serviceName={}, lastKnownVersion={})", serviceName, lastKnownVersion);
+
+        ServiceRMSMappings ret = null;
+
+        XXService xxService = serviceDao.findByName(serviceName);
+        if (xxService == null) {
+            LOG.error("Service not found: {}", serviceName);
+            return null;
+        }
+
+        XXRMSMappingProvider mappingProvider = getMappingProvider();
+        Long currentVersion = mappingProvider != null ? mappingProvider.getLastKnownVersion() : 0L;
+
+        if (lastKnownVersion != null && lastKnownVersion.equals(currentVersion)) {
+            LOG.debug("No changes since version {}", lastKnownVersion);
+            return null;
+        } else if (lastKnownVersion != null && lastKnownVersion > 0 && lastKnownVersion < currentVersion) {
+            ret = buildDeltaMappings(xxService, lastKnownVersion, currentVersion);
+        } else {
+            // Initial or refresh download: serve from the per-service memo so
+            // a thundering-herd of plugin restarts collapses to a single DB
+            // build per (service, version).
+            ret = buildOrGetCachedFullMappings(xxService, currentVersion);
+            ret.setLastKnownVersion(lastKnownVersion);
+            ret.setIsDelta(false);
+        }
+
+        LOG.debug("<== RMSMgr.getServiceMappings(serviceName={}, lastKnownVersion={}): mappingVersion={}, isDelta={}",
+                  serviceName, lastKnownVersion,
+                  ret != null ? ret.getMappingVersion() : null,
+                  ret != null ? ret.getIsDelta() : null);
+
+        return ret;
+    }
+
+    /**
+     * Build delta mappings: only mappings changed since lastKnownVersion.
+     * Returns isDelta=true with only changed/added mappings + removed GUIDs.
+     * Falls back to full download if deletion history is incomplete.
+     */
+    private ServiceRMSMappings buildDeltaMappings(XXService xxService, Long lastKnownVersion, Long currentVersion) {
+        LOG.info("Building delta mappings for {}: version {} -> {}", xxService.getName(), lastKnownVersion, currentVersion);
+
+        if (!hasDeletionHistorySince(lastKnownVersion)) {
+            LOG.info("Deletion history incomplete since version {}, falling back to full download", lastKnownVersion);
+            ServiceRMSMappings full = buildOrGetCachedFullMappings(xxService, currentVersion);
+            full.setIsDelta(false);
+            full.setLastKnownVersion(lastKnownVersion);
+            return full;
+        }
+
+        ServiceRMSMappings ret = new ServiceRMSMappings();
+        ret.setServiceName(xxService.getName());
+        ret.setMappingVersion(currentVersion);
+        ret.setLastKnownVersion(lastKnownVersion);
+        ret.setIsDelta(true);
+
+        List<Object[]> changedMappings = resourceMappingDao.findChangedMappingsForService(
+                xxService.getId(), lastKnownVersion, currentVersion);
+        // The DB query already restricts to mappings whose ll-resource belongs
+        // to xxService, so we skip the Java-side llService filter.
+        assembleMappings(changedMappings, xxService, ret, false);
+
+        List<DeletionRecord> deletions = getDeletionsSinceVersion(xxService.getId(), lastKnownVersion);
+        if (CollectionUtils.isNotEmpty(deletions)) {
+            for (DeletionRecord deletion : deletions) {
+                ret.addRemovedResourceGuid(deletion.llResourceGuid);
+            }
+        }
+
+        LOG.info("Delta built for {}: {} additions, {} removals (version {} -> {})",
+                 xxService.getName(),
+                 ret.getResourceMappings() != null ? ret.getResourceMappings().size() : 0,
+                 ret.getRemovedResourceGuids() != null ? ret.getRemovedResourceGuids().size() : 0,
+                 lastKnownVersion, currentVersion);
+
+        return ret;
+    }
+
+    /**
+     * Stampede-safe accessor for the fully-built mapping payload.
+     * <p>
+     * The hot path is a lock-free read of {@link #fullMappingsCache}; on a
+     * cache hit at the requested version we return a fresh
+     * {@link ServiceRMSMappings} header that <em>shares</em> the immutable
+     * resource-mapping list and resource map from the cache. Sharing is safe
+     * because nothing mutates those collections after they're populated by
+     * {@link #buildServiceMappings}.
+     * <p>
+     * On miss we serialize concurrent rebuilders behind a per-service lock,
+     * so 100 simultaneous full-sync requests collapse to a single DB build.
+     * Cache eviction is automatic: a stale (lower-version) entry simply
+     * fails the version check and is replaced under the lock.
+     */
+    private ServiceRMSMappings buildOrGetCachedFullMappings(XXService xxService, Long currentVersion) {
+        String name = xxService.getName();
+        long   wantVersion = currentVersion != null ? currentVersion : 0L;
+
+        CachedFullMappings hit = fullMappingsCache.get(name);
+        if (hit != null && hit.version == wantVersion) {
+            return wrapCachedFullMappings(hit);
+        }
+
+        Object lock = fullMappingsBuildLocks.computeIfAbsent(name, k -> new Object());
+        synchronized (lock) {
+            hit = fullMappingsCache.get(name);
+            if (hit != null && hit.version == wantVersion) {
+                return wrapCachedFullMappings(hit);
+            }
+            ServiceRMSMappings fresh = buildServiceMappings(xxService, currentVersion);
+            fullMappingsCache.put(name, new CachedFullMappings(fresh));
+            return fresh;
+        }
+    }
+
+    private ServiceRMSMappings wrapCachedFullMappings(CachedFullMappings cached) {
+        ServiceRMSMappings ret = new ServiceRMSMappings();
+        ret.setServiceName(cached.serviceName);
+        ret.setHlServiceName(cached.hlServiceName);
+        ret.setMappingVersion(cached.version);
+        ret.setIsDelta(false);
+        // Share immutable references with the cache. The REST layer only
+        // serializes these to JSON, never mutates them.
+        ret.setResourceMappings(cached.resourceMappings);
+        ret.setServiceResources(cached.serviceResources);
+        return ret;
+    }
+
+    /**
+     * Drop all cached full payloads. Called whenever a write operation
+     * mutates mappings; the next reader will rebuild from the source of
+     * truth at the new currentVersion. (Strictly speaking, the version
+     * check in the read path already guarantees correctness, but eagerly
+     * clearing avoids carrying obsolete bytes in memory.)
+     */
+    private void invalidateFullMappingsCache() {
+        fullMappingsCache.clear();
+    }
+
+    /**
+     * Build complete mappings for a service.
+     */
+    private ServiceRMSMappings buildServiceMappings(XXService xxService, Long mappingVersion) {
+        ServiceRMSMappings ret = new ServiceRMSMappings();
+        ret.setServiceName(xxService.getName());
+        ret.setMappingVersion(mappingVersion);
+        ret.setIsDelta(false);
+
+        String serviceType = getServiceType(xxService);
+        if (StringUtils.isBlank(serviceType)) {
+            return ret;
+        }
+
+        List<Object[]> mappings = resourceMappingDao.getResourceMappings();
+        if (CollectionUtils.isEmpty(mappings)) {
+            return ret;
+        }
+
+        // Full-mapping path returns rows for every service; filter to xxService in Java.
+        assembleMappings(mappings, xxService, ret, true);
+
+        return ret;
+    }
+
+    /**
+     * Hydrate (hlResourceId, llResourceId) tuples into {@code ret} using two
+     * batched DB queries instead of the previous N+1 per-row pattern:
+     * <ol>
+     *   <li>One IN-list lookup for all distinct resource ids touched.</li>
+     *   <li>One getById() per distinct hl-service id (cardinality is
+     *       typically a single digit, and JPA's persistence-context cache
+     *       collapses repeats within a transaction).</li>
+     * </ol>
+     * For deltas, callers must pass {@code filterByLlService=false} because
+     * the SQL query already restricts results to xxService. For full builds,
+     * pass {@code true} to drop rows whose ll-resource belongs to a different
+     * service.
+     */
+    private void assembleMappings(List<Object[]> rows,
+                                  XXService xxService,
+                                  ServiceRMSMappings ret,
+                                  boolean filterByLlService) {
+        if (CollectionUtils.isEmpty(rows)) {
+            return;
+        }
+
+        Set<Long> resourceIds = new HashSet<>(rows.size() * 2);
+        for (Object[] row : rows) {
+            Long hlId = (Long) row[0];
+            Long llId = (Long) row[1];
+            if (hlId != null) resourceIds.add(hlId);
+            if (llId != null) resourceIds.add(llId);
+        }
+
+        Map<Long, XXRMSServiceResource> resourcesById = serviceResourceDao.findByIds(resourceIds);
+        Map<Long, XXService> servicesById = new HashMap<>();
+
+        for (Object[] row : rows) {
+            Long hlResourceId = (Long) row[0];
+            Long llResourceId = (Long) row[1];
+
+            XXRMSServiceResource hlResource = resourcesById.get(hlResourceId);
+            XXRMSServiceResource llResource = resourcesById.get(llResourceId);
+
+            if (hlResource == null || llResource == null) {
+                continue;
+            }
+
+            if (filterByLlService) {
+                XXService llService = lookupServiceCached(llResource.getServiceId(), servicesById);
+                if (llService == null || !llService.getId().equals(xxService.getId())) {
+                    continue;
+                }
+            }
+
+            XXService hlService = lookupServiceCached(hlResource.getServiceId(), servicesById);
+            if (hlService != null) {
+                ret.setHlServiceName(hlService.getName());
+            }
+
+            RMSResourceMapping rmsMapping = new RMSResourceMapping();
+            rmsMapping.setHlResourceGuid(hlResource.getGuid());
+            rmsMapping.setLlResourceGuid(llResource.getGuid());
+            rmsMapping.setHlResourceElements(parseResourceElements(hlResource.getServiceResourceElements()));
+            rmsMapping.setLlResourceElements(parseResourceElements(llResource.getServiceResourceElements()));
+
+            ret.addResourceMapping(rmsMapping);
+
+            ret.addServiceResource(toRangerServiceResource(hlResource, hlService));
+            ret.addServiceResource(toRangerServiceResource(llResource, xxService));
+        }
+    }
+
+    private XXService lookupServiceCached(Long serviceId, Map<Long, XXService> cache) {
+        if (serviceId == null) {
+            return null;
+        }
+        XXService cached = cache.get(serviceId);
+        if (cached != null || cache.containsKey(serviceId)) {
+            return cached;
+        }
+        XXService loaded = serviceDao.getById(serviceId);
+        cache.put(serviceId, loaded);
+        return loaded;
+    }
+
+    private String getServiceType(XXService xxService) {
+        if (xxService == null || xxService.getType() == null) {
+            return null;
+        }
+        return svcStore.getServiceDefByIdForRMS(xxService.getType());
+    }
+
+    private RangerServiceResource toRangerServiceResource(XXRMSServiceResource xxResource, XXService xxService) {
+        RangerServiceResource ret = new RangerServiceResource();
+        ret.setId(xxResource.getId());
+        ret.setGuid(xxResource.getGuid());
+        ret.setServiceName(xxService != null ? xxService.getName() : null);
+        ret.setResourceElements(parseResourceElements(xxResource.getServiceResourceElements()));
+        ret.setResourceSignature(xxResource.getResourceSignature());
+        return ret;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, RangerPolicy.RangerPolicyResource> parseResourceElements(String resourceElementsText) {
+        if (StringUtils.isBlank(resourceElementsText)) {
+            return Collections.emptyMap();
+        }
+        try {
+            return JsonUtils.jsonToObject(resourceElementsText, Map.class);
+        } catch (Exception e) {
+            LOG.error("Failed to parse resource elements: {}", resourceElementsText, e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Create or update a resource mapping.
+     * @throws Exception if services cannot be resolved or resource creation fails
+     */
+    @Transactional
+    public void createOrUpdateMapping(String hlServiceName, Map<String, RangerPolicy.RangerPolicyResource> hlResource,
+                                       String llServiceName, Map<String, RangerPolicy.RangerPolicyResource> llResource,
+                                       String location) throws Exception {
+        LOG.debug("==> RMSMgr.createOrUpdateMapping(hlService={}, llService={}, location={})",
+                  hlServiceName, llServiceName, location);
+
+        XXService hlService = serviceDao.findByName(hlServiceName);
+        XXService llService = serviceDao.findByName(llServiceName);
+
+        if (hlService == null) {
+            throw new Exception("HL service not found: " + hlServiceName);
+        }
+        if (llService == null) {
+            throw new Exception("LL service not found: " + llServiceName);
+        }
+
+        XXRMSServiceResource hlSvcResource = findOrCreateServiceResource(hlService, hlResource);
+        XXRMSServiceResource llSvcResource = findOrCreateServiceResource(llService, llResource);
+
+        if (hlSvcResource == null) {
+            throw new Exception("Failed to create HL service resource for " + hlServiceName);
+        }
+        if (llSvcResource == null) {
+            throw new Exception("Failed to create LL service resource for " + llServiceName);
+        }
+
+        XXRMSResourceMapping existingMapping = resourceMappingDao.findByHlAndLlResourceId(
+            hlSvcResource.getId(), llSvcResource.getId());
+
+        if (existingMapping == null) {
+            // Genuine new mapping: bump the global version and persist it on the row.
+            Long newVersion = getNextMappingVersion();
+            XXRMSResourceMapping newMapping = new XXRMSResourceMapping();
+            newMapping.setHlResourceId(hlSvcResource.getId());
+            newMapping.setLlResourceId(llSvcResource.getId());
+            newMapping.setChangeTimestamp(new Date());
+            newMapping.setMappingVersion(newVersion);
+            resourceMappingDao.create(newMapping);
+            LOG.info("Created new RMS mapping: hl={}, ll={}, version={}",
+                     hlSvcResource.getGuid(), llSvcResource.getGuid(), newVersion);
+            updateMappingProviderVersion();
+        } else {
+            // The mapping is keyed by (hl_resource_id, ll_resource_id); both are
+            // resolved from stable signatures by findOrCreateServiceResource. If
+            // both look-ups returned existing rows AND the (hl, ll) pair is
+            // already in x_rms_resource_mapping, the mapping is unchanged. Do
+            // not bump mapping_version or the provider version — otherwise every
+            // full-sync would trigger every HDFS plugin to re-download the full
+            // mapping payload (isDelta=false) for no real change.
+            LOG.debug("RMS mapping unchanged (no-op): id={}, hl={}, ll={}, version={}",
+                      existingMapping.getId(), hlSvcResource.getGuid(),
+                      llSvcResource.getGuid(), existingMapping.getMappingVersion());
+        }
+
+        LOG.debug("<== RMSMgr.createOrUpdateMapping()");
+    }
+
+    /**
+     * Delete a resource mapping.
+     */
+    @Transactional
+    public void deleteMapping(String hlServiceName, Map<String, RangerPolicy.RangerPolicyResource> hlResource,
+                              String llServiceName, Map<String, RangerPolicy.RangerPolicyResource> llResource) {
+        LOG.debug("==> RMSMgr.deleteMapping(hlService={}, llService={})", hlServiceName, llServiceName);
+
+        XXService hlService = serviceDao.findByName(hlServiceName);
+        XXService llService = serviceDao.findByName(llServiceName);
+
+        if (hlService == null || llService == null) {
+            LOG.warn("Service not found for mapping deletion");
+            return;
+        }
+
+        String hlResourceSignature = computeResourceSignature(hlResource);
+        String llResourceSignature = computeResourceSignature(llResource);
+
+        XXRMSServiceResource hlSvcResource = serviceResourceDao.findByServiceAndResourceSignature(
+            hlService.getId(), hlResourceSignature);
+        XXRMSServiceResource llSvcResource = serviceResourceDao.findByServiceAndResourceSignature(
+            llService.getId(), llResourceSignature);
+
+        if (hlSvcResource != null && llSvcResource != null) {
+            XXRMSResourceMapping mapping = resourceMappingDao.findByHlAndLlResourceId(
+                hlSvcResource.getId(), llSvcResource.getId());
+            if (mapping != null) {
+                resourceMappingDao.remove(mapping.getId());
+                LOG.info("Deleted RMS mapping: id={}", mapping.getId());
+
+                // Record the deletion so that delta downloads return the removed
+                // LL resource GUID to plugins. Without this, plugins that use
+                // delta mode would never learn the mapping was removed and would
+                // continue to evaluate stale policies for the LL path.
+                List<DeletionRecord> deletions = new ArrayList<>();
+                deletions.add(new DeletionRecord(
+                    hlSvcResource.getGuid(), llSvcResource.getGuid(), llSvcResource.getServiceId()));
+
+                updateMappingProviderVersion();
+                Long version = getMappingProvider().getLastKnownVersion();
+                recordDeletions(version, deletions);
+
+                // If the LL resource is now orphaned (no other HL maps to it),
+                // drop the service-resource row too, mirroring deleteMappingsByHlResource.
+                List<Long> otherHlIds = resourceMappingDao.findByLlResourceId(llSvcResource.getId());
+                if (CollectionUtils.isEmpty(otherHlIds)) {
+                    serviceResourceDao.remove(llSvcResource.getId());
+                }
+            }
+        }
+
+        LOG.debug("<== RMSMgr.deleteMapping()");
+    }
+
+    /**
+     * Delete all mappings for a given HL (Hive) resource.
+     */
+    @Transactional
+    public void deleteMappingsByHlResource(String hlServiceName,
+                                            Map<String, RangerPolicy.RangerPolicyResource> hlResource) {
+        LOG.debug("==> RMSMgr.deleteMappingsByHlResource(hlService={})", hlServiceName);
+
+        XXService hlService = serviceDao.findByName(hlServiceName);
+        if (hlService == null) {
+            LOG.warn("Service not found for deletion: {}", hlServiceName);
+            return;
+        }
+
+        String resourceSignature = computeResourceSignature(hlResource);
+        XXRMSServiceResource hlSvcResource = serviceResourceDao.findByServiceAndResourceSignature(
+            hlService.getId(), resourceSignature);
+
+        if (hlSvcResource != null) {
+            List<Long> llResourceIds = resourceMappingDao.findByHlResourceId(hlSvcResource.getId());
+
+            List<DeletionRecord> deletions = new ArrayList<>();
+            if (CollectionUtils.isNotEmpty(llResourceIds)) {
+                for (Long llResourceId : llResourceIds) {
+                    XXRMSServiceResource llSvcResource = serviceResourceDao.getById(llResourceId);
+                    if (llSvcResource != null) {
+                        deletions.add(new DeletionRecord(
+                            hlSvcResource.getGuid(), llSvcResource.getGuid(), llSvcResource.getServiceId()));
+                    }
+                }
+            }
+
+            resourceMappingDao.deleteByHlResourceId(hlSvcResource.getId());
+            serviceResourceDao.remove(hlSvcResource.getId());
+
+            if (CollectionUtils.isNotEmpty(llResourceIds)) {
+                for (Long llResourceId : llResourceIds) {
+                    List<Long> otherHlIds = resourceMappingDao.findByLlResourceId(llResourceId);
+                    if (CollectionUtils.isEmpty(otherHlIds)) {
+                        serviceResourceDao.remove(llResourceId);
+                    }
+                }
+            }
+
+            updateMappingProviderVersion();
+
+            Long version = getMappingProvider().getLastKnownVersion();
+            recordDeletions(version, deletions);
+
+            LOG.info("Deleted RMS mappings for HL resource: signature={}, version={}", resourceSignature, version);
+        } else {
+            LOG.debug("No HL resource found for deletion: signature={}", resourceSignature);
+        }
+
+        LOG.debug("<== RMSMgr.deleteMappingsByHlResource()");
+    }
+
+    /**
+     * Perform full sync - clear all mappings and reload from HMS.
+     */
+    @Transactional
+    public void fullSync() {
+        LOG.info("==> RMSMgr.fullSync()");
+
+        List<XXRMSResourceMapping> allMappings = resourceMappingDao.getAll();
+        for (XXRMSResourceMapping mapping : allMappings) {
+            resourceMappingDao.remove(mapping.getId());
+        }
+
+        List<XXRMSNotification> allNotifications = notificationDao.getAll();
+        for (XXRMSNotification notification : allNotifications) {
+            notificationDao.remove(notification.getId());
+        }
+
+        List<XXRMSServiceResource> allResources = serviceResourceDao.getAll();
+        for (XXRMSServiceResource resource : allResources) {
+            serviceResourceDao.remove(resource.getId());
+        }
+
+        XXRMSMappingProvider provider = getMappingProvider();
+        if (provider != null) {
+            provider.setLastKnownVersion(0L);
+            mappingProviderDao.update(provider);
+        }
+
+        LOG.info("<== RMSMgr.fullSync(): Cleared all RMS data. Ready for fresh sync from HMS.");
+    }
+
+    /**
+     * Get or create mapping provider.
+     */
+    private XXRMSMappingProvider getMappingProvider() {
+        XXRMSMappingProvider provider = mappingProviderDao.findByName(RMS_MAPPING_PROVIDER_NAME);
+        if (provider == null) {
+            provider = new XXRMSMappingProvider();
+            provider.setName(RMS_MAPPING_PROVIDER_NAME);
+            provider.setLastKnownVersion(0L);
+            provider.setChangeTimestamp(new Date());
+            provider = mappingProviderDao.create(provider);
+        }
+        return provider;
+    }
+
+    /**
+     * Persist a batch of deletions made at {@code version}, then prune old
+     * entries that have aged out of the retention window. Runs inside the
+     * caller's transaction (callers are already {@code @Transactional}), so
+     * a deletion is durably visible to other Admin instances as soon as
+     * the enclosing transaction commits.
+     */
+    private void recordDeletions(Long version, List<DeletionRecord> deletions) {
+        if (version == null || CollectionUtils.isEmpty(deletions)) {
+            return;
+        }
+        List<XXRMSDeletionLog> rows = new ArrayList<>(deletions.size());
+        for (DeletionRecord d : deletions) {
+            rows.add(new XXRMSDeletionLog(version, d.hlResourceGuid, d.llResourceGuid, d.llServiceId));
+        }
+        deletionLogDao.recordAll(rows);
+        pruneOldDeletions(version);
+    }
+
+    /**
+     * Drop persisted deletion records older than the retention window and,
+     * if any rows were removed, advance the persisted watermark so plugins
+     * below the new minimum version are correctly forced to full-download.
+     */
+    private void pruneOldDeletions(Long currentVersion) {
+        if (currentVersion == null || currentVersion <= DELETION_LOG_RETAINED_VERSIONS) {
+            return;
+        }
+        long cutoff = currentVersion - DELETION_LOG_RETAINED_VERSIONS;
+        int removed = deletionLogDao.deleteOlderThanVersion(cutoff);
+        if (removed > 0) {
+            advanceDeletionTrackingTo(cutoff);
+            LOG.info("Pruned {} deletion-log rows older than version {}", removed, cutoff);
+        }
+    }
+
+    /**
+     * Return persisted deletion records affecting {@code serviceId} that
+     * happened strictly after {@code sinceVersion}. The query is bounded by
+     * an index on (ll_service_id, version) so multi-tenant Admins with one
+     * heavy tenant don't block lighter ones.
+     */
+    public List<DeletionRecord> getDeletionsSinceVersion(Long serviceId, Long sinceVersion) {
+        if (serviceId == null || sinceVersion == null) {
+            return Collections.emptyList();
+        }
+        List<XXRMSDeletionLog> rows = deletionLogDao.findByServiceSinceVersion(serviceId, sinceVersion);
+        if (CollectionUtils.isEmpty(rows)) {
+            return Collections.emptyList();
+        }
+        List<DeletionRecord> ret = new ArrayList<>(rows.size());
+        for (XXRMSDeletionLog row : rows) {
+            ret.add(new DeletionRecord(row.getHlResourceGuid(), row.getLlResourceGuid(), row.getLlServiceId()));
+        }
+        return ret;
+    }
+
+    /**
+     * Check whether the persisted deletion log is complete from
+     * {@code sinceVersion} onwards. The watermark lives on
+     * {@code x_rms_mapping_provider.deletion_tracking_from_version}, which
+     * is shared across every Admin instance and survives restart, so all
+     * Admins agree on the cutoff a plugin must be at to be served deltas.
+     *
+     * On a fresh upgrade the column is 0; the first check after upgrade
+     * lazily snapshots it to the then-current mapping version, after which
+     * it only moves forward when older records are pruned.
+     */
+    public boolean hasDeletionHistorySince(Long sinceVersion) {
+        if (sinceVersion == null) {
+            return false;
+        }
+        return sinceVersion >= getOrInitDeletionTrackingFromVersion();
+    }
+
+    /**
+     * Read the persisted deletion-tracking watermark, lazily snapshotting it
+     * on first call after upgrade.
+     * <p>
+     * Both the lazy-init and the subsequent reads use {@link
+     * XXRMSMappingProviderDao#initDeletionTrackingFromVersion} which writes
+     * <em>only</em> the watermark column with a guarded WHERE. This is critical
+     * because this method runs on the read (download) path and would otherwise
+     * race with the RMS poller's concurrent {@code last_known_version} write
+     * via {@code mappingProviderDao.update(entity)} — a stale read on the
+     * download side could overwrite the poller's bumped version (lost update).
+     */
+    private long getOrInitDeletionTrackingFromVersion() {
+        XXRMSMappingProvider provider = getMappingProvider();
+        Long persisted = provider != null ? provider.getDeletionTrackingFromVersion() : null;
+        if (persisted != null && persisted > 0L) {
+            return persisted;
+        }
+        if (provider == null) {
+            return 0L;
+        }
+        long current = provider.getLastKnownVersion() != null ? provider.getLastKnownVersion() : 0L;
+        int updated = mappingProviderDao.initDeletionTrackingFromVersion(RMS_MAPPING_PROVIDER_NAME, current);
+        if (updated > 0) {
+            LOG.info("Initialized persisted deletion-tracking watermark at mapping version {}", current);
+            return current;
+        }
+        // Either another Admin/thread won the race or the column is already
+        // set to a non-zero value; re-read to find the authoritative value.
+        Long fresh = mappingProviderDao.getEntityManager()
+                .createNamedQuery("XXRMSMappingProvider.findByName", XXRMSMappingProvider.class)
+                .setParameter("name", RMS_MAPPING_PROVIDER_NAME)
+                .getSingleResult()
+                .getDeletionTrackingFromVersion();
+        return fresh != null ? fresh : current;
+    }
+
+    /**
+     * Atomically move the watermark forward; no-op if already at/beyond
+     * {@code minVersion}. The update is monotonic forward-only at the SQL
+     * layer thanks to the {@code WHERE deletion_tracking_from_version &lt;
+     * :minVersion} guard, so concurrent calls (and concurrent Admins in HA)
+     * collapse safely.
+     */
+    private void advanceDeletionTrackingTo(long minVersion) {
+        mappingProviderDao.advanceDeletionTrackingFromVersion(RMS_MAPPING_PROVIDER_NAME, minVersion);
+    }
+
+    private Long getNextMappingVersion() {
+        XXRMSMappingProvider provider = getMappingProvider();
+        return provider != null ? provider.getLastKnownVersion() + 1 : 1L;
+    }
+
+    /**
+     * Update mapping provider version after changes. Also drops the cached
+     * full-mapping snapshots so subsequent readers rebuild against the new
+     * version. Strictly speaking the version check in the read path already
+     * guarantees correctness, but eager invalidation reclaims memory and
+     * keeps the cache state synchronized with the DB.
+     */
+    private void updateMappingProviderVersion() {
+        XXRMSMappingProvider provider = getMappingProvider();
+        if (provider != null) {
+            provider.setLastKnownVersion(provider.getLastKnownVersion() + 1);
+            provider.setChangeTimestamp(new Date());
+            mappingProviderDao.update(provider);
+            invalidateFullMappingsCache();
+        }
+    }
+
+    /**
+     * Find or create a service resource.
+     */
+    private XXRMSServiceResource findOrCreateServiceResource(XXService service,
+                                                              Map<String, RangerPolicy.RangerPolicyResource> resourceElements) {
+        if (service == null || MapUtils.isEmpty(resourceElements)) {
+            return null;
+        }
+
+        String resourceSignature = computeResourceSignature(resourceElements);
+        XXRMSServiceResource existing = serviceResourceDao.findByServiceAndResourceSignature(
+            service.getId(), resourceSignature);
+
+        if (existing != null) {
+            return existing;
+        }
+
+        XXRMSServiceResource newResource = new XXRMSServiceResource();
+        newResource.setGuid(guidUtil.genGUID());
+        newResource.setServiceId(service.getId());
+        newResource.setResourceSignature(resourceSignature);
+        newResource.setIsEnabled(true);
+        newResource.setServiceResourceElements(JsonUtils.objectToJson(resourceElements));
+        newResource.setCreateTime(new Date());
+        newResource.setUpdateTime(new Date());
+
+        return serviceResourceDao.create(newResource);
+    }
+
+    /**
+     * Compute a signature for resource elements.
+     */
+    private String computeResourceSignature(Map<String, RangerPolicy.RangerPolicyResource> resourceElements) {
+        if (MapUtils.isEmpty(resourceElements)) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        resourceElements.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> {
+                sb.append(entry.getKey()).append("=");
+                if (entry.getValue() != null && entry.getValue().getValues() != null) {
+                    sb.append(String.join(",", entry.getValue().getValues()));
+                }
+                sb.append(";");
+            });
+        return sb.toString();
+    }
+
+    /**
+     * Get the current mapping version.
+     */
+    @Transactional(readOnly = true)
+    public Long getMappingVersion() {
+        XXRMSMappingProvider provider = getMappingProvider();
+        return provider != null ? provider.getLastKnownVersion() : 0L;
+    }
+
+    /**
+     * Get mapping count for a service.
+     */
+    @Transactional(readOnly = true)
+    public long getMappingCount(String serviceName) {
+        XXService service = serviceDao.findByName(serviceName);
+        if (service == null) {
+            return 0;
+        }
+        List<RangerServiceResource> resources = serviceResourceDao.findByServiceId(service.getId());
+        return resources != null ? resources.size() : 0;
+    }
+
+    /**
+     * Get the last processed HMS event ID (persisted across restarts).
+     * Stored in the mapping provider's changeTimestamp field as epoch millis
+     * would waste precision; instead we encode it in the notification table.
+     * For simplicity, we use the x_rms_mapping_provider name column with a
+     * secondary record to store the event ID.
+     */
+    @Transactional(readOnly = true)
+    public long getLastProcessedEventId() {
+        XXRMSMappingProvider provider = mappingProviderDao.findByName("HMS_LAST_EVENT_ID");
+        if (provider != null) {
+            return provider.getLastKnownVersion() != null ? provider.getLastKnownVersion() : -1L;
+        }
+        return -1L;
+    }
+
+    @Transactional
+    public void saveLastProcessedEventId(long eventId) {
+        XXRMSMappingProvider provider = mappingProviderDao.findByName("HMS_LAST_EVENT_ID");
+        if (provider == null) {
+            provider = new XXRMSMappingProvider();
+            provider.setName("HMS_LAST_EVENT_ID");
+            provider.setLastKnownVersion(eventId);
+            provider.setChangeTimestamp(new Date());
+            mappingProviderDao.create(provider);
+        } else {
+            provider.setLastKnownVersion(eventId);
+            provider.setChangeTimestamp(new Date());
+            mappingProviderDao.update(provider);
+        }
+    }
+
+    /**
+     * Check if there are existing RMS mappings in the database.
+     */
+    @Transactional(readOnly = true)
+    public boolean hasExistingMappings() {
+        List<Object[]> mappings = resourceMappingDao.getResourceMappings();
+        return CollectionUtils.isNotEmpty(mappings);
+    }
+
+    /**
+     * Check if RMS is enabled for a service type.
+     */
+    public boolean isRMSEnabledForServiceType(String serviceType) {
+        return SERVICE_TYPE_HDFS.equalsIgnoreCase(serviceType) ||
+               SERVICE_TYPE_OZONE.equalsIgnoreCase(serviceType) ||
+               SERVICE_TYPE_S3.equalsIgnoreCase(serviceType);
+    }
+
+    /**
+     * Get the high-level service name (Hive) for a low-level service.
+     */
+    @Transactional(readOnly = true)
+    public String getHlServiceName(String llServiceName) {
+        List<Object[]> mappings = resourceMappingDao.getResourceMappings();
+        if (CollectionUtils.isEmpty(mappings)) {
+            return null;
+        }
+
+        XXService llService = serviceDao.findByName(llServiceName);
+        if (llService == null) {
+            return null;
+        }
+
+        for (Object[] mapping : mappings) {
+            Long hlResourceId = (Long) mapping[0];
+            Long llResourceId = (Long) mapping[1];
+
+            XXRMSServiceResource llResource = serviceResourceDao.getById(llResourceId);
+            if (llResource != null && llResource.getServiceId().equals(llService.getId())) {
+                XXRMSServiceResource hlResource = serviceResourceDao.getById(hlResourceId);
+                if (hlResource != null) {
+                    XXService hlService = serviceDao.getById(hlResource.getServiceId());
+                    if (hlService != null) {
+                        return hlService.getName();
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/biz/RMSMgr.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RMSMgr.java
@@ -39,6 +39,7 @@ import org.apache.ranger.entity.XXRMSServiceResource;
 import org.apache.ranger.entity.XXService;
 import org.apache.ranger.plugin.model.RangerPolicy;
 import org.apache.ranger.plugin.model.RangerServiceResource;
+import org.apache.ranger.plugin.store.RangerServiceResourceSignature;
 import org.apache.ranger.plugin.util.ServiceRMSMappings;
 import org.apache.ranger.plugin.util.ServiceRMSMappings.RMSResourceMapping;
 import org.slf4j.Logger;
@@ -60,6 +61,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * RMSMgr handles all Resource Mapping Server (RMS) business logic.
@@ -105,6 +107,33 @@ public class RMSMgr {
      * version field embedded in {@link CachedFullMappings} ensures stale
      * entries can never be served after a mapping write bumps the version.
      */
+    /**
+     * Bulk-full-sync mode. When the RMS poller runs {@code performFullSync}
+     * over a large HMS (hundreds of thousands to millions of tables), the
+     * per-row {@code updateMappingProviderVersion} bump becomes a hot lock:
+     * every {@code createOrUpdateMapping} takes a write lock on the single
+     * {@code x_rms_mapping_provider} row, killing parallelism.
+     *
+     * <p>Bulk mode defers the version bump: the poller calls
+     * {@link #beginBulkFullSync()} before the sync, {@link #endBulkFullSync(boolean)}
+     * after. During the window, new mapping rows are written with a reserved
+     * {@code pendingBulkVersion} but the provider row is NOT touched — plugins
+     * polling mid-sync see the previous version and receive "no change". On
+     * successful completion, the provider is bumped exactly once to the
+     * reserved version, cache is invalidated, plugins see the full new state
+     * on their next poll. If the sync fails (or the JVM crashes), the reserved
+     * version was never persisted to the provider row, so plugins never
+     * observed intermediate state — a restart re-runs the full sync from
+     * scratch and the previous partial writes are re-verified by the
+     * idempotent {@code createOrUpdateMapping} path.
+     *
+     * <p>Value semantics: {@code 0} means "not in bulk mode, bump per row";
+     * a positive value means "in bulk mode, use this as {@code mapping_version}
+     * for any new row, do not bump the provider".
+     */
+    private final AtomicLong pendingBulkVersion = new AtomicLong(0);
+    private final AtomicLong bulkModeWrittenRows = new AtomicLong(0);
+
     private static final int FULL_MAPPINGS_CACHE_CAPACITY = 16;
     private final Map<String, CachedFullMappings> fullMappingsCache =
             Collections.synchronizedMap(new LinkedHashMap<String, CachedFullMappings>(
@@ -378,6 +407,21 @@ public class RMSMgr {
         Map<Long, XXRMSServiceResource> resourcesById = serviceResourceDao.findByIds(resourceIds);
         Map<Long, XXService> servicesById = new HashMap<>();
 
+        // At scale (100K+ mappings) the biggest wall-clock cost in this method
+        // is JSON re-parsing: the naive version parsed each service resource's
+        // {@code service_resource_elements_text} FOUR times per row (twice for
+        // {@code RMSResourceMapping}, twice for {@code RangerServiceResource}
+        // built inside {@code toRangerServiceResource}). At 790K mappings that
+        // is 3.16M parses — the dominant cost on a cold-cache full download.
+        //
+        // Reduce this to a single parse per unique resource, memoized in
+        // {@code parsedElementsById}. The parsed map is then shared by
+        // reference across the mapping and the ServiceResource; JSON output
+        // is unchanged (Jackson serializes the shared map the same way each
+        // reference is encountered).
+        Map<Long, Map<String, RangerPolicy.RangerPolicyResource>> parsedElementsById =
+                new HashMap<>(resourcesById.size() * 2);
+
         for (Object[] row : rows) {
             Long hlResourceId = (Long) row[0];
             Long llResourceId = (Long) row[1];
@@ -401,17 +445,40 @@ public class RMSMgr {
                 ret.setHlServiceName(hlService.getName());
             }
 
+            Map<String, RangerPolicy.RangerPolicyResource> hlElems = parsedElementsById.computeIfAbsent(
+                    hlResourceId, id -> parseResourceElements(hlResource.getServiceResourceElements()));
+            Map<String, RangerPolicy.RangerPolicyResource> llElems = parsedElementsById.computeIfAbsent(
+                    llResourceId, id -> parseResourceElements(llResource.getServiceResourceElements()));
+
             RMSResourceMapping rmsMapping = new RMSResourceMapping();
             rmsMapping.setHlResourceGuid(hlResource.getGuid());
             rmsMapping.setLlResourceGuid(llResource.getGuid());
-            rmsMapping.setHlResourceElements(parseResourceElements(hlResource.getServiceResourceElements()));
-            rmsMapping.setLlResourceElements(parseResourceElements(llResource.getServiceResourceElements()));
+            rmsMapping.setHlResourceElements(hlElems);
+            rmsMapping.setLlResourceElements(llElems);
 
             ret.addResourceMapping(rmsMapping);
 
-            ret.addServiceResource(toRangerServiceResource(hlResource, hlService));
-            ret.addServiceResource(toRangerServiceResource(llResource, xxService));
+            ret.addServiceResource(toRangerServiceResourceWithElems(hlResource, hlService, hlElems));
+            ret.addServiceResource(toRangerServiceResourceWithElems(llResource, xxService, llElems));
         }
+    }
+
+    /**
+     * Build a {@link RangerServiceResource} from a pre-parsed resource-element
+     * map, avoiding the re-parse that {@link #toRangerServiceResource} would
+     * otherwise incur. Used from the hot assembly path where the caller
+     * already computed / memoized the parsed elements for this resource.
+     */
+    private RangerServiceResource toRangerServiceResourceWithElems(XXRMSServiceResource xxResource,
+                                                                    XXService xxService,
+                                                                    Map<String, RangerPolicy.RangerPolicyResource> parsedElements) {
+        RangerServiceResource ret = new RangerServiceResource();
+        ret.setId(xxResource.getId());
+        ret.setGuid(xxResource.getGuid());
+        ret.setServiceName(xxService != null ? xxService.getName() : null);
+        ret.setResourceElements(parsedElements);
+        ret.setResourceSignature(xxResource.getResourceSignature());
+        return ret;
     }
 
     private XXService lookupServiceCached(Long serviceId, Map<Long, XXService> cache) {
@@ -492,17 +559,30 @@ public class RMSMgr {
             hlSvcResource.getId(), llSvcResource.getId());
 
         if (existingMapping == null) {
-            // Genuine new mapping: bump the global version and persist it on the row.
-            Long newVersion = getNextMappingVersion();
+            // Genuine new mapping. In bulk-full-sync mode the version is
+            // pre-reserved and the provider row is deliberately NOT bumped
+            // per-row — see pendingBulkVersion javadoc. Outside bulk mode
+            // (event-driven mutations after initial sync), keep the original
+            // per-mapping bump semantics.
+            long bulkVersion = pendingBulkVersion.get();
+            Long newVersion;
+            if (bulkVersion > 0) {
+                newVersion = bulkVersion;
+                bulkModeWrittenRows.incrementAndGet();
+            } else {
+                newVersion = getNextMappingVersion();
+            }
             XXRMSResourceMapping newMapping = new XXRMSResourceMapping();
             newMapping.setHlResourceId(hlSvcResource.getId());
             newMapping.setLlResourceId(llSvcResource.getId());
             newMapping.setChangeTimestamp(new Date());
             newMapping.setMappingVersion(newVersion);
             resourceMappingDao.create(newMapping);
-            LOG.info("Created new RMS mapping: hl={}, ll={}, version={}",
-                     hlSvcResource.getGuid(), llSvcResource.getGuid(), newVersion);
-            updateMappingProviderVersion();
+            LOG.debug("Created new RMS mapping: hl={}, ll={}, version={}, bulk={}",
+                     hlSvcResource.getGuid(), llSvcResource.getGuid(), newVersion, bulkVersion > 0);
+            if (bulkVersion == 0) {
+                updateMappingProviderVersion();
+            }
         } else {
             // The mapping is keyed by (hl_resource_id, ll_resource_id); both are
             // resolved from stable signatures by findOrCreateServiceResource. If
@@ -823,6 +903,76 @@ public class RMSMgr {
     }
 
     /**
+     * Enter bulk-full-sync mode: reserve the next mapping version for
+     * every row written during the sync window and suppress the per-row
+     * provider bump. Idempotent — a second call while already in bulk mode
+     * returns the previously-reserved version without changing state, which
+     * lets the RMS poller retry safely on transient errors without
+     * double-reserving.
+     *
+     * @return the reserved {@code mapping_version} that new rows will use.
+     */
+    @Transactional
+    public long beginBulkFullSync() {
+        long existing = pendingBulkVersion.get();
+        if (existing > 0) {
+            LOG.info("beginBulkFullSync(): already in bulk mode at pendingVersion={}", existing);
+            return existing;
+        }
+        XXRMSMappingProvider provider = getMappingProvider();
+        long currentVersion = provider != null && provider.getLastKnownVersion() != null
+                ? provider.getLastKnownVersion() : 0L;
+        long reserved = currentVersion + 1;
+        pendingBulkVersion.set(reserved);
+        bulkModeWrittenRows.set(0);
+        LOG.info("beginBulkFullSync(): reserved pendingVersion={} (currentVersion={})",
+                reserved, currentVersion);
+        return reserved;
+    }
+
+    /**
+     * Exit bulk-full-sync mode. On successful completion with at least one
+     * new mapping written, commits the reserved version to the provider row
+     * (single atomic bump) and invalidates the full-mappings cache so
+     * subsequent plugin polls see the new state. On failure, or when nothing
+     * new was written, discards the reservation without touching the
+     * provider row — plugins never observed the intermediate state.
+     *
+     * @param success   whether the sync ran to completion
+     */
+    @Transactional
+    public void endBulkFullSync(boolean success) {
+        long reserved = pendingBulkVersion.getAndSet(0);
+        long written = bulkModeWrittenRows.getAndSet(0);
+        if (reserved == 0) {
+            LOG.debug("endBulkFullSync(success={}): not in bulk mode, ignoring", success);
+            return;
+        }
+        if (!success) {
+            LOG.warn("endBulkFullSync(success=false): discarding reserved pendingVersion={} "
+                    + "(writtenRows={}). Provider version unchanged; next full sync will retry.",
+                    reserved, written);
+            return;
+        }
+        if (written == 0) {
+            LOG.info("endBulkFullSync(success=true): no new rows written at pendingVersion={}, "
+                    + "provider version unchanged", reserved);
+            return;
+        }
+        XXRMSMappingProvider provider = getMappingProvider();
+        if (provider != null) {
+            long committed = provider.getLastKnownVersion() != null
+                    ? provider.getLastKnownVersion() + 1 : 1L;
+            provider.setLastKnownVersion(committed);
+            provider.setChangeTimestamp(new Date());
+            mappingProviderDao.update(provider);
+            invalidateFullMappingsCache();
+            LOG.info("endBulkFullSync(success=true): committed version={} (reservedWas={}, writtenRows={})",
+                    committed, reserved, written);
+        }
+    }
+
+    /**
      * Find or create a service resource.
      */
     private XXRMSServiceResource findOrCreateServiceResource(XXService service,
@@ -851,24 +1001,13 @@ public class RMSMgr {
         return serviceResourceDao.create(newResource);
     }
 
-    /**
-     * Compute a signature for resource elements.
-     */
     private String computeResourceSignature(Map<String, RangerPolicy.RangerPolicyResource> resourceElements) {
         if (MapUtils.isEmpty(resourceElements)) {
             return "";
         }
-        StringBuilder sb = new StringBuilder();
-        resourceElements.entrySet().stream()
-            .sorted(Map.Entry.comparingByKey())
-            .forEach(entry -> {
-                sb.append(entry.getKey()).append("=");
-                if (entry.getValue() != null && entry.getValue().getValues() != null) {
-                    sb.append(String.join(",", entry.getValue().getValues()));
-                }
-                sb.append(";");
-            });
-        return sb.toString();
+        RangerServiceResource sr = new RangerServiceResource();
+        sr.setResourceElements(resourceElements);
+        return new RangerServiceResourceSignature(sr).getSignature();
     }
 
     /**

--- a/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/RangerBizUtil.java
@@ -479,6 +479,18 @@ public class RangerBizUtil {
 	}
 
 	/**
+	 * True when the operator has opted into unauthenticated download access
+	 * (typically {@code ranger.admin.allow.unauthenticated.download.access=true}).
+	 * Used by download endpoints that need to conditionally skip strong
+	 * client-side auth checks (e.g. mutual-TLS cert validation) when the
+	 * operator has already declared the plugin trust boundary elsewhere
+	 * (SPNEGO/Kerberos + per-service allow-list).
+	 */
+	public boolean isUnauthenticatedDownloadAccessAllowed() {
+		return allowUnauthenticatedDownloadAccessInSecureEnvironment;
+	}
+
+	/**
 	 * returns true if user is having required permission on given Hbase
 	 * resource
 	 *

--- a/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
+++ b/security-admin/src/main/java/org/apache/ranger/biz/ServiceDBStore.java
@@ -5414,6 +5414,22 @@ public class ServiceDBStore extends AbstractServiceStore {
 		daoMgr.getXXRMSResourceMapping();
 	}
 
+	/**
+	 * Get service definition name by service type ID (used by RMS).
+	 */
+	public String getServiceDefByIdForRMS(Long serviceDefId) {
+		if (serviceDefId == null) {
+			return null;
+		}
+		try {
+			RangerServiceDef serviceDef = getServiceDef(serviceDefId);
+			return serviceDef != null ? serviceDef.getName() : null;
+		} catch (Exception e) {
+			LOG.error("Failed to get service def by id: " + serviceDefId, e);
+			return null;
+		}
+	}
+
 	public void resetPolicyUpdateLog(int retentionInDays, Integer policyChangeType) {
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("==> resetPolicyUpdateLog(" + retentionInDays + ", " + policyChangeType + ")");

--- a/security-admin/src/main/java/org/apache/ranger/db/RangerDaoManagerBase.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/RangerDaoManagerBase.java
@@ -323,6 +323,7 @@ public abstract class RangerDaoManagerBase {
 	public XXRMSNotificationDao getXXRMSNotification() { return new XXRMSNotificationDao(this); }
 	public XXRMSServiceResourceDao getXXRMSServiceResource() { return new XXRMSServiceResourceDao(this); }
 	public XXRMSResourceMappingDao getXXRMSResourceMapping() { return new XXRMSResourceMappingDao(this); }
+	public XXRMSDeletionLogDao getXXRMSDeletionLog() { return new XXRMSDeletionLogDao(this); }
 
 	public XXGdsDatasetDao getXXGdsDataset() { return new XXGdsDatasetDao(this); }
 	public XXGdsProjectDao getXXGdsProject() { return new XXGdsProjectDao(this); }

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRMSDeletionLogDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRMSDeletionLogDao.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ranger.db;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import javax.persistence.NoResultException;
+
+import org.apache.ranger.common.db.BaseDao;
+import org.apache.ranger.entity.XXRMSDeletionLog;
+import org.springframework.stereotype.Service;
+
+/**
+ * DAO for {@link XXRMSDeletionLog}, the persistent record of deleted RMS
+ * mappings used to construct correct delta downloads across Admin restarts
+ * and HA failovers. Entry points:
+ * <ul>
+ *   <li>{@link #recordAll(Collection)} appends a batch of deletions for a
+ *       single mapping_version.</li>
+ *   <li>{@link #findByServiceSinceVersion(Long, Long)} returns the
+ *       deletions a plugin needs to apply to advance its local cache.</li>
+ *   <li>{@link #getMinVersion()} feeds the deletion-tracking watermark
+ *       check.</li>
+ *   <li>{@link #deleteOlderThanVersion(Long)} prunes old records.</li>
+ * </ul>
+ */
+@Service
+public class XXRMSDeletionLogDao extends BaseDao<XXRMSDeletionLog> {
+
+    public XXRMSDeletionLogDao(RangerDaoManagerBase daoManager) {
+        super(daoManager);
+    }
+
+    public void recordAll(Collection<XXRMSDeletionLog> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+        for (XXRMSDeletionLog row : rows) {
+            getEntityManager().persist(row);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<XXRMSDeletionLog> findByServiceSinceVersion(Long serviceId, Long sinceVersion) {
+        if (serviceId == null || sinceVersion == null) {
+            return Collections.emptyList();
+        }
+        try {
+            return getEntityManager()
+                    .createNamedQuery("XXRMSDeletionLog.findByServiceSinceVersion")
+                    .setParameter("serviceId", serviceId)
+                    .setParameter("sinceVersion", sinceVersion)
+                    .getResultList();
+        } catch (NoResultException e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Returns the smallest version present in the deletion log, or
+     * {@code null} if the log is empty. An empty log paired with a
+     * watermark on {@code XXRMSMappingProvider} is the post-upgrade /
+     * fresh-install state.
+     */
+    public Long getMinVersion() {
+        try {
+            return (Long) getEntityManager()
+                    .createNamedQuery("XXRMSDeletionLog.getMinVersion")
+                    .getSingleResult();
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Delete every deletion record whose version is strictly less than
+     * {@code minRetainedVersion}. Returns the number of rows affected.
+     */
+    public int deleteOlderThanVersion(Long minRetainedVersion) {
+        if (minRetainedVersion == null) {
+            return 0;
+        }
+        return getEntityManager()
+                .createNamedQuery("XXRMSDeletionLog.deleteOlderThanVersion")
+                .setParameter("minRetainedVersion", minRetainedVersion)
+                .executeUpdate();
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRMSMappingProviderDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRMSMappingProviderDao.java
@@ -81,7 +81,48 @@ public class XXRMSMappingProviderDao extends BaseDao<XXRMSMappingProvider> {
         }
     }
 
+    /**
+     * Snapshot the deletion-tracking watermark on first delta poll after upgrade.
+     * <p>
+     * Writes only the {@code deletion_tracking_from_version} column and only if
+     * no real value was ever persisted (NULL or 0). This avoids the lost-update
+     * hazard with the RMS poller's concurrent {@code last_known_version} write
+     * which would otherwise occur if we re-saved the whole entity from a stale
+     * read on the read path.
+     *
+     * @return number of rows updated (0 if already initialized).
+     */
+    public int initDeletionTrackingFromVersion(String providerName, long initVersion) {
+        if (providerName == null) {
+            return 0;
+        }
+        return getEntityManager()
+                .createNamedQuery("XXRMSMappingProvider.initDeletionTrackingFromVersion")
+                .setParameter("name", providerName)
+                .setParameter("initVersion", initVersion)
+                .executeUpdate();
+    }
 
-
+    /**
+     * Advance the deletion-tracking watermark forward (monotonic).
+     * <p>
+     * The query uses a {@code WHERE deletion_tracking_from_version < :minVersion}
+     * guard, so concurrent advances and lazy-inits are safe: only updates that
+     * truly move the watermark forward are applied. As above, this writes only
+     * the watermark column to avoid clobbering {@code last_known_version}.
+     *
+     * @return number of rows updated (0 if the watermark is already at or
+     *         beyond {@code minVersion}).
+     */
+    public int advanceDeletionTrackingFromVersion(String providerName, long minVersion) {
+        if (providerName == null) {
+            return 0;
+        }
+        return getEntityManager()
+                .createNamedQuery("XXRMSMappingProvider.advanceDeletionTrackingFromVersion")
+                .setParameter("name", providerName)
+                .setParameter("minVersion", minVersion)
+                .executeUpdate();
+    }
 }
 

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRMSResourceMappingDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRMSResourceMappingDao.java
@@ -45,6 +45,32 @@ public class XXRMSResourceMappingDao extends BaseDao<XXRMSResourceMapping> {
 		return getEntityManager().createNamedQuery("XXRMSResourceMapping.getResourceMapping").getResultList();
 	}
 
+	@SuppressWarnings("unchecked")
+	public List<Object[]> getResourceMappingsSinceVersion(Long sinceVersion) {
+		return getEntityManager()
+			.createNamedQuery("XXRMSResourceMapping.getResourceMappingsSinceVersion")
+			.setParameter("sinceVersion", sinceVersion)
+			.getResultList();
+	}
+
+	/**
+	 * Return all resource mappings whose low-level resource belongs to the
+	 * given service and whose mapping_version falls in the half-open
+	 * interval (sinceVersion, currentVersion]. The upper bound prevents
+	 * read-skew between the version snapshot and the row scan; the
+	 * service-scoped filter keeps multi-tenant deltas from pulling rows for
+	 * unrelated services.
+	 */
+	@SuppressWarnings("unchecked")
+	public List<Object[]> findChangedMappingsForService(Long serviceId, Long sinceVersion, Long currentVersion) {
+		return getEntityManager()
+			.createNamedQuery("XXRMSResourceMapping.findChangedMappingsForService")
+			.setParameter("serviceId", serviceId)
+			.setParameter("sinceVersion", sinceVersion)
+			.setParameter("currentVersion", currentVersion)
+			.getResultList();
+	}
+
 	public void deleteByHlResourceId(Long resourceId) {
 		getEntityManager()
 			.createNamedQuery("XXRMSResourceMapping.deleteByHlResourceId")

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRMSServiceResourceDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRMSServiceResourceDao.java
@@ -20,7 +20,11 @@
 package org.apache.ranger.db;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.persistence.NoResultException;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -43,6 +47,54 @@ public class XXRMSServiceResourceDao extends BaseDao<XXRMSServiceResource> {
 	public XXRMSServiceResourceDao(RangerDaoManagerBase daoManager) {
 		super(daoManager);
 		_daoManager = daoManager;
+	}
+
+	/**
+	 * Maximum number of ids per batched IN-list query. EclipseLink and most
+	 * RDBMSs cap parameter list sizes (Oracle famously at 1000); chunking
+	 * keeps the implementation portable without a per-vendor branch.
+	 */
+	private static final int FIND_BY_IDS_BATCH_SIZE = 500;
+
+	/**
+	 * Batched id-keyed lookup. Returns a map of id -> entity for every id
+	 * that exists; missing ids are simply absent from the result. Avoids
+	 * the N+1 calls that arise from looping on getById() during delta and
+	 * full-mapping builds in {@code RMSMgr}.
+	 */
+	@SuppressWarnings("unchecked")
+	public Map<Long, XXRMSServiceResource> findByIds(Collection<Long> ids) {
+		if (ids == null || ids.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Long, XXRMSServiceResource> ret = new HashMap<>(ids.size() * 2);
+		List<Long> batch = new ArrayList<>(FIND_BY_IDS_BATCH_SIZE);
+		for (Long id : ids) {
+			if (id == null) {
+				continue;
+			}
+			batch.add(id);
+			if (batch.size() >= FIND_BY_IDS_BATCH_SIZE) {
+				loadByIdsBatch(batch, ret);
+				batch.clear();
+			}
+		}
+		if (!batch.isEmpty()) {
+			loadByIdsBatch(batch, ret);
+		}
+		return ret;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void loadByIdsBatch(List<Long> ids, Map<Long, XXRMSServiceResource> sink) {
+		List<XXRMSServiceResource> rows = getEntityManager()
+				.createNamedQuery("XXRMSServiceResource.findByIds", tClass)
+				.setParameter("ids", ids)
+				.getResultList();
+		for (XXRMSServiceResource row : rows) {
+			sink.put(row.getId(), row);
+		}
 	}
 
 	public XXRMSServiceResource findByGuid(String guid) {

--- a/security-admin/src/main/java/org/apache/ranger/db/XXRMSServiceResourceDao.java
+++ b/security-admin/src/main/java/org/apache/ranger/db/XXRMSServiceResourceDao.java
@@ -88,9 +88,24 @@ public class XXRMSServiceResourceDao extends BaseDao<XXRMSServiceResource> {
 
 	@SuppressWarnings("unchecked")
 	private void loadByIdsBatch(List<Long> ids, Map<Long, XXRMSServiceResource> sink) {
+		// eclipselink.read-only: don't register fetched entities in the UnitOfWork.
+		// Without this, EclipseLink runs UnitOfWorkImpl.calculateChanges() on every
+		// query — an O(N²) walk of the persistence context that dominates wall-clock
+		// on cold full-download builds at scale (empirically: batch 3160 iterates
+		// ~1.58M attached entities per query for a 790K-mapping repository).
+		//
+		// Safe here because assembleMappings only reads the entities' getters; it
+		// never mutates or persists them, and the enclosing transaction is
+		// @Transactional(readOnly=true).
+		//
+		// jpa.query.flush-mode COMMIT is a defensive belt-and-suspenders: even if
+		// something else in the same transaction dirtied the context, we do not want
+		// to trigger a pre-query flush for a read-only batch lookup.
 		List<XXRMSServiceResource> rows = getEntityManager()
 				.createNamedQuery("XXRMSServiceResource.findByIds", tClass)
 				.setParameter("ids", ids)
+				.setHint("eclipselink.read-only", "true")
+				.setFlushMode(javax.persistence.FlushModeType.COMMIT)
 				.getResultList();
 		for (XXRMSServiceResource row : rows) {
 			sink.put(row.getId(), row);

--- a/security-admin/src/main/java/org/apache/ranger/entity/XXRMSDeletionLog.java
+++ b/security-admin/src/main/java/org/apache/ranger/entity/XXRMSDeletionLog.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.ranger.entity;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * Persisted record of a deleted RMS resource mapping. The set of rows in
+ * this table at a given mapping_version represents the deletions that
+ * happened to bring the mapping graph up to that version. Plugins consuming
+ * incremental delta downloads use these rows to remove resources from their
+ * local cache.
+ *
+ * The table is append-only during normal operation and is pruned on a fixed
+ * retention window defined in {@code RMSMgr}; pruning advances the
+ * deletion-tracking watermark stored on
+ * {@link XXRMSMappingProvider#deletionTrackingFromVersion}.
+ */
+@Entity
+@Cacheable(false)
+@Table(name = "x_rms_deletion_log")
+public class XXRMSDeletionLog implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @SequenceGenerator(name = "X_RMS_DELETION_LOG_SEQ", sequenceName = "X_RMS_DELETION_LOG_SEQ", allocationSize = 1)
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "X_RMS_DELETION_LOG_SEQ")
+    @Column(name = "id")
+    protected Long id;
+
+    @Column(name = "version")
+    protected Long version;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "change_timestamp")
+    protected Date changeTimestamp;
+
+    @Column(name = "hl_resource_guid", length = 64)
+    protected String hlResourceGuid;
+
+    @Column(name = "ll_resource_guid", length = 64)
+    protected String llResourceGuid;
+
+    @Column(name = "ll_service_id")
+    protected Long llServiceId;
+
+    public XXRMSDeletionLog() {}
+
+    public XXRMSDeletionLog(Long version, String hlResourceGuid, String llResourceGuid, Long llServiceId) {
+        this.version = version;
+        this.changeTimestamp = new Date();
+        this.hlResourceGuid = hlResourceGuid;
+        this.llResourceGuid = llResourceGuid;
+        this.llServiceId = llServiceId;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getVersion() { return version; }
+    public void setVersion(Long version) { this.version = version; }
+
+    public Date getChangeTimestamp() { return changeTimestamp; }
+    public void setChangeTimestamp(Date changeTimestamp) { this.changeTimestamp = changeTimestamp; }
+
+    public String getHlResourceGuid() { return hlResourceGuid; }
+    public void setHlResourceGuid(String hlResourceGuid) { this.hlResourceGuid = hlResourceGuid; }
+
+    public String getLlResourceGuid() { return llResourceGuid; }
+    public void setLlResourceGuid(String llResourceGuid) { this.llResourceGuid = llResourceGuid; }
+
+    public Long getLlServiceId() { return llServiceId; }
+    public void setLlServiceId(Long llServiceId) { this.llServiceId = llServiceId; }
+
+    @Override
+    public String toString() {
+        return "XXRMSDeletionLog{id=" + id +
+                ", version=" + version +
+                ", changeTimestamp=" + changeTimestamp +
+                ", hlResourceGuid='" + hlResourceGuid + '\'' +
+                ", llResourceGuid='" + llResourceGuid + '\'' +
+                ", llServiceId=" + llServiceId +
+                '}';
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/entity/XXRMSMappingProvider.java
+++ b/security-admin/src/main/java/org/apache/ranger/entity/XXRMSMappingProvider.java
@@ -62,6 +62,17 @@ public class XXRMSMappingProvider implements Serializable {
     @Column(name = "last_known_version")
     protected Long lastKnownVersion;
 
+    /**
+     * Lowest mapping_version from which the persisted deletion log (table
+     * {@code x_rms_deletion_log}) is known to be complete. Plugins polling
+     * with a {@code lastKnownVersion} below this value cannot be served a
+     * delta safely and must full-download. Set lazily on the first delta
+     * request after upgrade to the then-current {@code lastKnownVersion},
+     * and advanced forward whenever older deletion records are pruned.
+     */
+    @Column(name = "deletion_tracking_from_version")
+    protected Long deletionTrackingFromVersion;
+
     public XXRMSMappingProvider() {}
 
     public XXRMSMappingProvider(String name) {
@@ -105,6 +116,14 @@ public class XXRMSMappingProvider implements Serializable {
      */
     public void setLastKnownVersion(Long lastKnownVersion) {
         this.lastKnownVersion = lastKnownVersion;
+    }
+
+    public Long getDeletionTrackingFromVersion() {
+        return deletionTrackingFromVersion;
+    }
+
+    public void setDeletionTrackingFromVersion(Long deletionTrackingFromVersion) {
+        this.deletionTrackingFromVersion = deletionTrackingFromVersion;
     }
 
     public int getMyClassType() {

--- a/security-admin/src/main/java/org/apache/ranger/entity/XXRMSResourceMapping.java
+++ b/security-admin/src/main/java/org/apache/ranger/entity/XXRMSResourceMapping.java
@@ -78,6 +78,15 @@ public class XXRMSResourceMapping implements Serializable {
 		this.llResourceId = llResourceId;
 	}
 
+	@Column(name="mapping_version")
+	protected Long mappingVersion;
+	public Long getMappingVersion() {
+		return mappingVersion;
+	}
+	public void setMappingVersion(Long mappingVersion) {
+		this.mappingVersion = mappingVersion;
+	}
+
 	public int getMyClassType() {
 		return AppConstants.CLASS_TYPE_RMS_RESOURCE_MAPPING;
 	}

--- a/security-admin/src/main/java/org/apache/ranger/rest/RMSREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RMSREST.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.rest;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.biz.AssetMgr;
+import org.apache.ranger.biz.RMSMgr;
+import org.apache.ranger.biz.RangerBizUtil;
+import org.apache.ranger.biz.ServiceDBStore;
+import org.apache.ranger.common.RESTErrorUtil;
+import org.apache.ranger.common.RangerSearchUtil;
+import org.apache.ranger.common.ServiceUtil;
+import org.apache.ranger.db.RangerDaoManager;
+import org.apache.ranger.rms.RangerRMSPollerService;
+import org.apache.ranger.entity.XXService;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.plugin.util.RangerPerfTracer;
+import org.apache.ranger.plugin.util.ServiceRMSMappings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * RMSREST provides REST API endpoints for Resource Mapping Server (RMS) functionality.
+ * This enables Hive-to-Storage (HDFS/Ozone/S3) policy synchronization.
+ */
+@Path("rms")
+@Component
+@Scope("request")
+@Transactional(propagation = Propagation.REQUIRES_NEW)
+public class RMSREST {
+    private static final Logger LOG = LoggerFactory.getLogger(RMSREST.class);
+    private static final Logger PERF_LOG = RangerPerfTracer.getPerfLogger("rest.RMSREST");
+
+    private static final String PARAM_LAST_KNOWN_VERSION = "lastKnownVersion";
+    private static final String PARAM_PLUGIN_ID = "pluginId";
+
+    @Autowired
+    RESTErrorUtil restErrorUtil;
+
+    @Autowired
+    RMSMgr rmsMgr;
+
+    @Autowired
+    ServiceDBStore svcStore;
+
+    @Autowired
+    RangerDaoManager daoManager;
+
+    @Autowired
+    RangerBizUtil bizUtil;
+
+    @Autowired
+    AssetMgr assetMgr;
+
+    @Autowired
+    RangerSearchUtil searchUtil;
+
+    @Autowired
+    ServiceUtil serviceUtil;
+
+    @Autowired(required = false)
+    RangerRMSPollerService rmsPollerService;
+
+    /**
+     * Download resource mappings for a service.
+     * Used by HDFS/Ozone/S3 plugins to get Hive-to-Storage mappings.
+     */
+    @GET
+    @Path("/mappings/download/{serviceName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getServiceMappings(
+            @PathParam("serviceName") String serviceName,
+            @QueryParam(PARAM_LAST_KNOWN_VERSION) Long lastKnownVersion,
+            @QueryParam(PARAM_PLUGIN_ID) String pluginId,
+            @Context HttpServletRequest request) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.getServiceMappings(serviceName={}, lastKnownVersion={}, pluginId={})",
+                      serviceName, lastKnownVersion, pluginId);
+        }
+
+        RangerPerfTracer perf = null;
+        if (RangerPerfTracer.isPerfTraceEnabled(PERF_LOG)) {
+            perf = RangerPerfTracer.getPerfTracer(PERF_LOG, "RMSREST.getServiceMappings(serviceName=" + serviceName + ")");
+        }
+
+        try {
+            if (StringUtils.isBlank(serviceName)) {
+                throw restErrorUtil.createRESTException("serviceName cannot be empty");
+            }
+
+            XXService xxService = daoManager.getXXService().findByName(serviceName);
+            if (xxService == null) {
+                throw restErrorUtil.createRESTException("Service not found: " + serviceName);
+            }
+
+            // Apply the same authn/authz controls as /service/plugins/policies/download/{serviceName}.
+            // The endpoint is excluded from Spring Security (security="none") so the gating must
+            // happen here: reject anonymous downloads when not allowed and validate the plugin's
+            // service-level credentials (when configured).
+            bizUtil.failUnauthenticatedDownloadIfNotAllowed();
+
+            if (!serviceUtil.isValidateHttpsAuthentication(serviceName, request)) {
+                throw restErrorUtil.createRESTException(
+                    HttpServletResponse.SC_UNAUTHORIZED,
+                    "Unauthorized RMS mapping download for service: " + serviceName,
+                    true);
+            }
+
+            if (!isRMSDownloadAllowed(serviceName)) {
+                throw restErrorUtil.createRESTException(
+                    HttpServletResponse.SC_FORBIDDEN,
+                    "User is not authorized to download RMS mappings for service: " + serviceName,
+                    true);
+            }
+
+            ServiceRMSMappings ret = rmsMgr.getServiceMappings(serviceName, lastKnownVersion);
+
+            if (ret == null) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("No RMS mapping changes for service={}, version={}", serviceName, lastKnownVersion);
+                }
+                return Response.notModified().build();
+            }
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("<== RMSREST.getServiceMappings(serviceName={}): mappingVersion={}, isDelta={}",
+                          serviceName, ret.getMappingVersion(), ret.getIsDelta());
+            }
+
+            return Response.ok(ret).build();
+
+        } catch (WebApplicationException excp) {
+            throw excp;
+        } catch (Exception e) {
+            LOG.error("Failed to get RMS mappings for service: " + serviceName, e);
+            throw restErrorUtil.createRESTException("Failed to get RMS mappings: " + e.getMessage());
+        } finally {
+            RangerPerfTracer.log(perf);
+        }
+    }
+
+    /**
+     * Get the current mapping version for a service.
+     */
+    @GET
+    @Path("/mappings/version")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Object> getMappingVersion() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.getMappingVersion()");
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+        try {
+            Long version = rmsMgr.getMappingVersion();
+            ret.put("mappingVersion", version);
+            ret.put("status", "success");
+        } catch (Exception e) {
+            LOG.error("Failed to get mapping version", e);
+            ret.put("status", "error");
+            ret.put("message", e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.getMappingVersion(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Create or update a resource mapping.
+     * Called by HMS notification listener when tables/databases are created or modified.
+     */
+    @POST
+    @Path("/mappings")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public Map<String, Object> createOrUpdateMapping(RMSMappingRequest mappingRequest) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.createOrUpdateMapping({})", mappingRequest);
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+
+        try {
+            if (mappingRequest == null) {
+                throw restErrorUtil.createRESTException("Mapping request cannot be null");
+            }
+
+            rmsMgr.createOrUpdateMapping(
+                mappingRequest.getHlServiceName(),
+                mappingRequest.getHlResourceElements(),
+                mappingRequest.getLlServiceName(),
+                mappingRequest.getLlResourceElements(),
+                mappingRequest.getLocation()
+            );
+
+            ret.put("status", "success");
+            ret.put("message", "Mapping created/updated successfully");
+
+        } catch (WebApplicationException excp) {
+            throw excp;
+        } catch (Exception e) {
+            LOG.error("Failed to create/update mapping", e);
+            throw restErrorUtil.createRESTException("Failed to create/update mapping: " + e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.createOrUpdateMapping(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Delete a resource mapping.
+     * Called by HMS notification listener when tables/databases are dropped.
+     */
+    @DELETE
+    @Path("/mappings")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public Map<String, Object> deleteMapping(RMSMappingRequest mappingRequest) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.deleteMapping({})", mappingRequest);
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+
+        try {
+            if (mappingRequest == null) {
+                throw restErrorUtil.createRESTException("Mapping request cannot be null");
+            }
+
+            rmsMgr.deleteMapping(
+                mappingRequest.getHlServiceName(),
+                mappingRequest.getHlResourceElements(),
+                mappingRequest.getLlServiceName(),
+                mappingRequest.getLlResourceElements()
+            );
+
+            ret.put("status", "success");
+            ret.put("message", "Mapping deleted successfully");
+
+        } catch (WebApplicationException excp) {
+            throw excp;
+        } catch (Exception e) {
+            LOG.error("Failed to delete mapping", e);
+            throw restErrorUtil.createRESTException("Failed to delete mapping: " + e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.deleteMapping(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Trigger a full sync - clears all mappings and waits for HMS to repopulate.
+     */
+    @POST
+    @Path("/mappings/fullsync")
+    @Produces(MediaType.APPLICATION_JSON)
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public Map<String, Object> fullSync() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.fullSync()");
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+
+        try {
+            rmsMgr.fullSync();
+            ret.put("status", "success");
+            ret.put("message", "Full sync initiated. All RMS mappings cleared.");
+
+        } catch (Exception e) {
+            LOG.error("Failed to perform full sync", e);
+            throw restErrorUtil.createRESTException("Failed to perform full sync: " + e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.fullSync(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Get mapping statistics.
+     */
+    @GET
+    @Path("/mappings/stats/{serviceName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN') or hasRole('ROLE_ADMIN_AUDITOR') or hasRole('ROLE_KEY_ADMIN_AUDITOR')")
+    public Map<String, Object> getMappingStats(@PathParam("serviceName") String serviceName) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.getMappingStats(serviceName={})", serviceName);
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+
+        try {
+            if (StringUtils.isBlank(serviceName)) {
+                throw restErrorUtil.createRESTException("serviceName cannot be empty");
+            }
+
+            long mappingCount = rmsMgr.getMappingCount(serviceName);
+            Long mappingVersion = rmsMgr.getMappingVersion();
+            String hlServiceName = rmsMgr.getHlServiceName(serviceName);
+
+            ret.put("serviceName", serviceName);
+            ret.put("mappingCount", mappingCount);
+            ret.put("mappingVersion", mappingVersion);
+            ret.put("hlServiceName", hlServiceName);
+            ret.put("status", "success");
+
+        } catch (WebApplicationException excp) {
+            throw excp;
+        } catch (Exception e) {
+            LOG.error("Failed to get mapping stats for service: " + serviceName, e);
+            throw restErrorUtil.createRESTException("Failed to get mapping stats: " + e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.getMappingStats(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Get RMS poller service status.
+     */
+    @GET
+    @Path("/poller/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public Map<String, Object> getPollerStatus() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.getPollerStatus()");
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+
+        try {
+            if (rmsPollerService != null) {
+                ret.put("enabled", rmsPollerService.isEnabled());
+                ret.put("fullSyncCompleted", rmsPollerService.isFullSyncCompleted());
+                ret.put("lastEventId", rmsPollerService.getLastEventId());
+                ret.put("status", "running");
+            } else {
+                ret.put("enabled", false);
+                ret.put("status", "not_initialized");
+                ret.put("message", "RMS Poller Service is not available. Check if ranger.rms.enabled=true and HMS URI is configured.");
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to get poller status", e);
+            ret.put("status", "error");
+            ret.put("error", e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.getPollerStatus(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Trigger a full sync from HMS.
+     */
+    @POST
+    @Path("/poller/fullsync")
+    @Produces(MediaType.APPLICATION_JSON)
+    @PreAuthorize("hasRole('ROLE_SYS_ADMIN')")
+    public Map<String, Object> triggerPollerFullSync() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("==> RMSREST.triggerPollerFullSync()");
+        }
+
+        Map<String, Object> ret = new HashMap<>();
+
+        try {
+            if (rmsPollerService != null && rmsPollerService.isEnabled()) {
+                rmsPollerService.triggerFullSync();
+                ret.put("status", "success");
+                ret.put("message", "Full sync triggered. It will be executed in the next polling cycle.");
+            } else {
+                ret.put("status", "error");
+                ret.put("message", "RMS Poller Service is not enabled or not available.");
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to trigger full sync", e);
+            ret.put("status", "error");
+            ret.put("error", e.getMessage());
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("<== RMSREST.triggerPollerFullSync(): {}", ret);
+        }
+
+        return ret;
+    }
+
+    /**
+     * Final coarse-grained check on top of the upstream gates
+     * (failUnauthenticatedDownloadIfNotAllowed + isValidateHttpsAuthentication).
+     * Confirms that the requested service still exists; the actual plugin/user
+     * authorization is delegated to ServiceUtil.isValidateHttpsAuthentication
+     * which honors policy.download.auth.users / tag.download.auth.users.
+     */
+    private boolean isRMSDownloadAllowed(String serviceName) {
+        try {
+            XXService xxService = daoManager.getXXService().findByName(serviceName);
+            return xxService != null;
+        } catch (Exception e) {
+            LOG.error("Error checking RMS download authorization", e);
+            return false;
+        }
+    }
+
+    /**
+     * Request object for creating/deleting RMS mappings.
+     */
+    public static class RMSMappingRequest {
+        private String hlServiceName;
+        private String llServiceName;
+        private Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements;
+        private Map<String, RangerPolicy.RangerPolicyResource> llResourceElements;
+        private String location;
+
+        public String getHlServiceName() {
+            return hlServiceName;
+        }
+
+        public void setHlServiceName(String hlServiceName) {
+            this.hlServiceName = hlServiceName;
+        }
+
+        public String getLlServiceName() {
+            return llServiceName;
+        }
+
+        public void setLlServiceName(String llServiceName) {
+            this.llServiceName = llServiceName;
+        }
+
+        public Map<String, RangerPolicy.RangerPolicyResource> getHlResourceElements() {
+            return hlResourceElements;
+        }
+
+        public void setHlResourceElements(Map<String, RangerPolicy.RangerPolicyResource> hlResourceElements) {
+            this.hlResourceElements = hlResourceElements;
+        }
+
+        public Map<String, RangerPolicy.RangerPolicyResource> getLlResourceElements() {
+            return llResourceElements;
+        }
+
+        public void setLlResourceElements(Map<String, RangerPolicy.RangerPolicyResource> llResourceElements) {
+            this.llResourceElements = llResourceElements;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public void setLocation(String location) {
+            this.location = location;
+        }
+
+        @Override
+        public String toString() {
+            return "RMSMappingRequest{" +
+                   "hlServiceName='" + hlServiceName + '\'' +
+                   ", llServiceName='" + llServiceName + '\'' +
+                   ", hlResourceElements=" + hlResourceElements +
+                   ", llResourceElements=" + llResourceElements +
+                   ", location='" + location + '\'' +
+                   '}';
+        }
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/rest/RMSREST.java
+++ b/security-admin/src/main/java/org/apache/ranger/rest/RMSREST.java
@@ -140,7 +140,21 @@ public class RMSREST {
             // service-level credentials (when configured).
             bizUtil.failUnauthenticatedDownloadIfNotAllowed();
 
-            if (!serviceUtil.isValidateHttpsAuthentication(serviceName, request)) {
+            // Mutual-TLS client-cert validation. In clusters where the plugin
+            // authenticates via SPNEGO/Kerberos instead of a client cert
+            // (common on ODP), this check throws. ServiceREST's
+            // /service/plugins/policies/download/{svc} tolerates the same
+            // failure by catching the exception and falling through to a
+            // SPNEGO+allow-list path; we mirror that behavior here so the
+            // RMS endpoint reaches parity with the policy endpoint. The
+            // operator's declaration in
+            // {@code ranger.admin.allow.unauthenticated.download.access=true}
+            // is the trust-boundary signal: if it's on, the cluster is
+            // relying on the upstream Kerberos servlet filter for auth and
+            // the cert check is redundant. If it's off, we still enforce
+            // strict mutual-TLS.
+            if (!bizUtil.isUnauthenticatedDownloadAccessAllowed()
+                    && !serviceUtil.isValidateHttpsAuthentication(serviceName, request)) {
                 throw restErrorUtil.createRESTException(
                     HttpServletResponse.SC_UNAUTHORIZED,
                     "Unauthorized RMS mapping download for service: " + serviceName,

--- a/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
@@ -1,0 +1,569 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.rms;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * HMSClientWrapper provides a reflection-based wrapper for Hive Metastore
+ * using raw Thrift transport with support for plain, Kerberos/SASL, and SSL connections.
+ *
+ * Transport modes:
+ * - PLAIN:    raw TSocket -> TFramedTransport -> TBinaryProtocol  (default, non-secure)
+ * - SASL:     raw TSocket -> TSaslClientTransport (GSSAPI) -> TBinaryProtocol  (Kerberos)
+ * - SSL:      TSSLTransportFactory.getClientSocket -> TBinaryProtocol  (SSL/TLS)
+ * - SSL+SASL: TSSLTransportFactory.getClientSocket -> TSaslClientTransport -> TBinaryProtocol
+ *
+ * At runtime, ensure these JARs are in the classpath:
+ * - hive-standalone-metastore-common (contains ThriftHiveMetastore API)
+ * - libthrift (Thrift transport/protocol)
+ * - libfb303 (Thrift fb303 base)
+ */
+public class HMSClientWrapper implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(HMSClientWrapper.class);
+
+    private static final String THRIFT_CLIENT_CLASS = "org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client";
+    private static final String TSOCKET_CLASS = "org.apache.thrift.transport.TSocket";
+    private static final String TTRANSPORT_CLASS = "org.apache.thrift.transport.TTransport";
+    private static final String TBINARY_PROTOCOL_CLASS = "org.apache.thrift.protocol.TBinaryProtocol";
+    private static final String TPROTOCOL_CLASS = "org.apache.thrift.protocol.TProtocol";
+    private static final String TFRAMED_TRANSPORT_CLASS = "org.apache.thrift.transport.TFramedTransport";
+    private static final String TBUFFERED_TRANSPORT_CLASS = "org.apache.thrift.transport.TBufferedTransport";
+    private static final String TSASL_CLIENT_TRANSPORT_CLASS = "org.apache.thrift.transport.TSaslClientTransport";
+    private static final String TSSL_TRANSPORT_FACTORY_CLASS = "org.apache.thrift.transport.TSSLTransportFactory";
+    private static final String TSSL_TRANSPORT_PARAMS_CLASS = "org.apache.thrift.transport.TSSLTransportFactory$TSSLTransportParameters";
+
+    private static final int DEFAULT_SOCKET_TIMEOUT_MS = 30000;
+
+    private Object thriftClient;
+    private Object transport;
+    private boolean connected = false;
+
+    private boolean saslEnabled = false;
+    private String kerberosServerPrincipal;
+    private boolean sslEnabled = false;
+    private String truststorePath;
+    private String truststorePassword;
+
+    public HMSClientWrapper() {
+    }
+
+    public void setSaslEnabled(boolean saslEnabled) {
+        this.saslEnabled = saslEnabled;
+    }
+
+    public void setKerberosServerPrincipal(String kerberosServerPrincipal) {
+        this.kerberosServerPrincipal = kerberosServerPrincipal;
+    }
+
+    public void setSslEnabled(boolean sslEnabled) {
+        this.sslEnabled = sslEnabled;
+    }
+
+    public void setTruststorePath(String truststorePath) {
+        this.truststorePath = truststorePath;
+    }
+
+    public void setTruststorePassword(String truststorePassword) {
+        this.truststorePassword = truststorePassword;
+    }
+
+    /**
+     * Connect to HMS using raw Thrift transport.
+     */
+    public boolean connect(String hmsUri) {
+        LOG.info("Connecting to HMS at: {} (sasl={}, ssl={})", hmsUri, saslEnabled, sslEnabled);
+
+        try {
+            URI uri = new URI(hmsUri);
+            String host = uri.getHost();
+            int port = uri.getPort();
+
+            if (StringUtils.isBlank(host)) {
+                LOG.error("Invalid HMS URI - no host: {}", hmsUri);
+                return false;
+            }
+            if (port <= 0) {
+                port = 9083;
+            }
+
+            LOG.info("Parsed HMS endpoint: host={}, port={}", host, port);
+
+            return connectViaThrift(host, port);
+
+        } catch (Exception e) {
+            LOG.error("Failed to parse HMS URI: {}", hmsUri, e);
+            return false;
+        }
+    }
+
+    private boolean connectViaThrift(String host, int port) {
+        try {
+            LOG.info("Creating Thrift connection to {}:{} (timeout={}ms, sasl={}, ssl={})",
+                     host, port, DEFAULT_SOCKET_TIMEOUT_MS, saslEnabled, sslEnabled);
+
+            Class<?> ttransportClass = Class.forName(TTRANSPORT_CLASS);
+            Object baseTransport;
+
+            if (sslEnabled) {
+                baseTransport = createSSLTransport(host, port, ttransportClass);
+            } else {
+                baseTransport = createPlainSocket(host, port, ttransportClass);
+            }
+
+            if (baseTransport == null) {
+                LOG.error("Failed to create base transport");
+                return false;
+            }
+
+            Object finalTransport;
+            if (saslEnabled) {
+                finalTransport = wrapWithSASL(baseTransport, host, ttransportClass);
+                if (finalTransport == null) {
+                    LOG.error("Failed to wrap transport with SASL");
+                    cleanupTransport(baseTransport, ttransportClass);
+                    return false;
+                }
+            } else {
+                finalTransport = baseTransport;
+            }
+
+            this.transport = finalTransport;
+
+            Method isOpenMethod = ttransportClass.getMethod("isOpen");
+            Boolean alreadyOpen = (Boolean) isOpenMethod.invoke(this.transport);
+            if (!Boolean.TRUE.equals(alreadyOpen)) {
+                LOG.info("Opening Thrift transport...");
+                Method openMethod = ttransportClass.getMethod("open");
+                openMethod.invoke(this.transport);
+            }
+            LOG.info("Thrift transport opened successfully");
+
+            Class<?> tprotocolClass = Class.forName(TPROTOCOL_CLASS);
+            Class<?> tbinaryClass = Class.forName(TBINARY_PROTOCOL_CLASS);
+            Constructor<?> protocolCtor = tbinaryClass.getConstructor(ttransportClass);
+            Object protocol = protocolCtor.newInstance(this.transport);
+
+            Class<?> clientClass = Class.forName(THRIFT_CLIENT_CLASS);
+            Constructor<?> clientCtor = clientClass.getConstructor(tprotocolClass);
+            thriftClient = clientCtor.newInstance(protocol);
+            LOG.info("ThriftHiveMetastore.Client created successfully");
+
+            connected = true;
+            LOG.info("Connected to HMS at {}:{}", host, port);
+            return true;
+
+        } catch (ClassNotFoundException e) {
+            LOG.error("Required Thrift class not found: {}. Ensure libthrift and hive-standalone-metastore-common JARs are in classpath.", e.getMessage());
+            cleanupOnFailure();
+            return false;
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            LOG.error("Failed to connect to HMS: {}", cause != null ? cause.getMessage() : e.getMessage());
+            if (cause != null) {
+                LOG.error("Root cause:", cause);
+            }
+            cleanupOnFailure();
+            return false;
+        } catch (Exception e) {
+            LOG.error("Failed to connect to HMS via Thrift: {}", e.getMessage(), e);
+            cleanupOnFailure();
+            return false;
+        }
+    }
+
+    private Object createPlainSocket(String host, int port, Class<?> ttransportClass) throws Exception {
+        Class<?> tsocketClass = Class.forName(TSOCKET_CLASS);
+        Constructor<?> tsocketCtor = tsocketClass.getConstructor(String.class, int.class, int.class);
+        Object tsocket = tsocketCtor.newInstance(host, port, DEFAULT_SOCKET_TIMEOUT_MS);
+        LOG.info("TSocket created");
+
+        Object wrapped = wrapTransport(tsocket, ttransportClass);
+        return wrapped != null ? wrapped : tsocket;
+    }
+
+    private Object createSSLTransport(String host, int port, Class<?> ttransportClass) {
+        try {
+            Class<?> sslFactoryClass = Class.forName(TSSL_TRANSPORT_FACTORY_CLASS);
+            Class<?> sslParamsClass = Class.forName(TSSL_TRANSPORT_PARAMS_CLASS);
+
+            Object sslParams = sslParamsClass.getDeclaredConstructor().newInstance();
+
+            if (StringUtils.isNotBlank(truststorePath)) {
+                Method setTrustStore = sslParamsClass.getMethod("setTrustStore", String.class, String.class);
+                setTrustStore.invoke(sslParams, truststorePath, truststorePassword != null ? truststorePassword : "");
+                LOG.info("SSL truststore configured: {}", truststorePath);
+            }
+
+            Method getClientSocket = sslFactoryClass.getMethod("getClientSocket",
+                String.class, int.class, int.class, sslParamsClass);
+            Object sslTransport = getClientSocket.invoke(null, host, port, DEFAULT_SOCKET_TIMEOUT_MS, sslParams);
+            LOG.info("SSL transport created to {}:{}", host, port);
+            return sslTransport;
+        } catch (ClassNotFoundException e) {
+            LOG.error("SSL transport classes not found. Ensure libthrift JAR supports TSSLTransportFactory: {}", e.getMessage());
+        } catch (Exception e) {
+            LOG.error("Failed to create SSL transport to {}:{}: {}", host, port, e.getMessage(), e);
+        }
+        return null;
+    }
+
+    private Object wrapWithSASL(Object baseTransport, String host, Class<?> ttransportClass) {
+        try {
+            String principal = kerberosServerPrincipal;
+            if (StringUtils.isBlank(principal)) {
+                LOG.error("Kerberos server principal is required for SASL but not configured");
+                return null;
+            }
+
+            String[] principalParts = principal.split("[/@]");
+            String servicePrincipalName = principalParts.length > 0 ? principalParts[0] : "hive";
+            String serverHost = principalParts.length > 1 ? principalParts[1] : host;
+
+            if ("_HOST".equalsIgnoreCase(serverHost)) {
+                serverHost = host;
+            }
+
+            LOG.info("Creating SASL GSSAPI transport: service={}, host={}", servicePrincipalName, serverHost);
+
+            Class<?> saslClass = Class.forName(TSASL_CLIENT_TRANSPORT_CLASS);
+
+            java.util.Map<String, String> saslProps = new java.util.HashMap<>();
+            saslProps.put("javax.security.sasl.qop", "auth");
+            saslProps.put("javax.security.sasl.server.authentication", "true");
+
+            // libthrift >= 0.9.x (including 0.16) exposes a 7-arg constructor with
+            // an authorizationId as the 2nd parameter. Some much older Thrift versions
+            // had a 6-arg variant without authorizationId. Try 7-arg first, fall back
+            // to 6-arg for backwards-compatibility.
+            Constructor<?> saslCtor;
+            Object saslTransport;
+            try {
+                saslCtor = saslClass.getConstructor(
+                    String.class,          // mechanism
+                    String.class,          // authorizationId
+                    String.class,          // protocol
+                    String.class,          // serverName
+                    java.util.Map.class,   // props
+                    javax.security.auth.callback.CallbackHandler.class,
+                    ttransportClass        // transport
+                );
+                saslTransport = saslCtor.newInstance(
+                    "GSSAPI", null, servicePrincipalName, serverHost, saslProps, null, baseTransport);
+            } catch (NoSuchMethodException nsme7) {
+                LOG.debug("7-arg TSaslClientTransport ctor not found, trying 6-arg legacy variant");
+                saslCtor = saslClass.getConstructor(
+                    String.class,          // mechanism
+                    String.class,          // protocol
+                    String.class,          // serverName
+                    java.util.Map.class,   // props
+                    javax.security.auth.callback.CallbackHandler.class,
+                    ttransportClass        // transport
+                );
+                saslTransport = saslCtor.newInstance(
+                    "GSSAPI", servicePrincipalName, serverHost, saslProps, null, baseTransport);
+            }
+            LOG.info("SASL GSSAPI transport created");
+            return saslTransport;
+
+        } catch (ClassNotFoundException e) {
+            LOG.error("TSaslClientTransport not found. Ensure libthrift supports SASL: {}", e.getMessage());
+        } catch (Exception e) {
+            LOG.error("Failed to create SASL transport: {}", e.getMessage(), e);
+        }
+        return null;
+    }
+
+    /**
+     * Connect with Kerberos authentication using a Subject from UserGroupInformation.
+     */
+    public boolean connectAsKerberosUser(String hmsUri) {
+        LOG.info("Connecting to HMS with Kerberos authentication at: {}", hmsUri);
+        try {
+            Class<?> ugiClass = Class.forName("org.apache.hadoop.security.UserGroupInformation");
+            Method getLoginUser = ugiClass.getMethod("getLoginUser");
+            Object loginUser = getLoginUser.invoke(null);
+
+            if (loginUser == null) {
+                LOG.warn("No Kerberos login user available, falling back to plain connect");
+                return connect(hmsUri);
+            }
+
+            Method doAs = ugiClass.getMethod("doAs", PrivilegedExceptionAction.class);
+            Boolean result = (Boolean) doAs.invoke(loginUser, (PrivilegedExceptionAction<Boolean>) () -> connect(hmsUri));
+            return Boolean.TRUE.equals(result);
+
+        } catch (ClassNotFoundException e) {
+            LOG.warn("Hadoop UserGroupInformation not available, falling back to plain connect");
+            return connect(hmsUri);
+        } catch (Exception e) {
+            LOG.error("Failed to connect using Kerberos: {}", e.getMessage(), e);
+            return false;
+        }
+    }
+
+    private Object wrapTransport(Object tsocket, Class<?> ttransportClass) {
+        try {
+            Class<?> tframedClass = Class.forName(TFRAMED_TRANSPORT_CLASS);
+            Constructor<?> ctor = tframedClass.getConstructor(ttransportClass);
+            Object framed = ctor.newInstance(tsocket);
+            LOG.info("Using TFramedTransport");
+            return framed;
+        } catch (ClassNotFoundException e) {
+            LOG.debug("TFramedTransport not found");
+        } catch (Exception e) {
+            LOG.debug("Could not create TFramedTransport: {}", e.getMessage());
+        }
+
+        try {
+            Class<?> tbufferedClass = Class.forName(TBUFFERED_TRANSPORT_CLASS);
+            Constructor<?> ctor = tbufferedClass.getConstructor(ttransportClass);
+            Object buffered = ctor.newInstance(tsocket);
+            LOG.info("Using TBufferedTransport");
+            return buffered;
+        } catch (ClassNotFoundException e) {
+            LOG.debug("TBufferedTransport not found");
+        } catch (Exception e) {
+            LOG.debug("Could not create TBufferedTransport: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
+    public List<String> getAllDatabases() throws Exception {
+        ensureConnected();
+        Method method = thriftClient.getClass().getMethod("get_all_databases");
+        @SuppressWarnings("unchecked")
+        List<String> result = (List<String>) method.invoke(thriftClient);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    public List<String> getAllTables(String dbName) throws Exception {
+        ensureConnected();
+        Method method = thriftClient.getClass().getMethod("get_all_tables", String.class);
+        @SuppressWarnings("unchecked")
+        List<String> result = (List<String>) method.invoke(thriftClient, dbName);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    public DatabaseInfo getDatabase(String dbName) throws Exception {
+        ensureConnected();
+        Method method = thriftClient.getClass().getMethod("get_database", String.class);
+        Object database = method.invoke(thriftClient, dbName);
+
+        if (database == null) {
+            return null;
+        }
+
+        DatabaseInfo info = new DatabaseInfo();
+        info.name = (String) database.getClass().getMethod("getName").invoke(database);
+        info.locationUri = (String) database.getClass().getMethod("getLocationUri").invoke(database);
+        return info;
+    }
+
+    public TableInfo getTable(String dbName, String tableName) throws Exception {
+        ensureConnected();
+        Method method = thriftClient.getClass().getMethod("get_table", String.class, String.class);
+        Object table = method.invoke(thriftClient, dbName, tableName);
+
+        if (table == null) {
+            return null;
+        }
+
+        TableInfo info = new TableInfo();
+        info.dbName = (String) table.getClass().getMethod("getDbName").invoke(table);
+        info.tableName = (String) table.getClass().getMethod("getTableName").invoke(table);
+        info.tableType = (String) table.getClass().getMethod("getTableType").invoke(table);
+
+        Object sd = table.getClass().getMethod("getSd").invoke(table);
+        if (sd != null) {
+            info.location = (String) sd.getClass().getMethod("getLocation").invoke(sd);
+        }
+
+        return info;
+    }
+
+    public long getCurrentNotificationEventId() throws Exception {
+        ensureConnected();
+        Method method = thriftClient.getClass().getMethod("get_current_notificationEventId");
+        Object result = method.invoke(thriftClient);
+
+        if (result != null) {
+            Method getEventIdMethod = result.getClass().getMethod("getEventId");
+            return (Long) getEventIdMethod.invoke(result);
+        }
+
+        return -1;
+    }
+
+    public List<NotificationEventInfo> getNextNotification(long lastEventId, int maxEvents) throws Exception {
+        ensureConnected();
+        List<NotificationEventInfo> results = new ArrayList<>();
+
+        try {
+            Class<?> requestClass = Class.forName("org.apache.hadoop.hive.metastore.api.NotificationEventRequest");
+            Object request = requestClass.getDeclaredConstructor().newInstance();
+            requestClass.getMethod("setLastEvent", long.class).invoke(request, lastEventId);
+            requestClass.getMethod("setMaxEvents", int.class).invoke(request, maxEvents);
+
+            Method method = thriftClient.getClass().getMethod("get_next_notification", requestClass);
+            Object response = method.invoke(thriftClient, request);
+
+            if (response != null) {
+                Method getEventsMethod = response.getClass().getMethod("getEvents");
+                @SuppressWarnings("unchecked")
+                List<?> events = (List<?>) getEventsMethod.invoke(response);
+
+                if (events != null) {
+                    for (Object event : events) {
+                        NotificationEventInfo info = new NotificationEventInfo();
+                        info.eventId = (Long) event.getClass().getMethod("getEventId").invoke(event);
+                        info.eventType = (String) event.getClass().getMethod("getEventType").invoke(event);
+                        info.dbName = (String) event.getClass().getMethod("getDbName").invoke(event);
+                        info.tableName = (String) event.getClass().getMethod("getTableName").invoke(event);
+                        try {
+                            info.message = (String) event.getClass().getMethod("getMessage").invoke(event);
+                        } catch (Exception msgEx) {
+                            LOG.debug("Could not extract message from event {}: {}", info.eventId, msgEx.getMessage());
+                        }
+                        results.add(info);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error getting notifications from HMS: {}", e.getMessage());
+            throw new Exception("Failed to get HMS notifications: " + e.getMessage(), e);
+        }
+
+        return results;
+    }
+
+    public boolean testConnection() {
+        try {
+            getAllDatabases();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (transport != null) {
+            try {
+                Class<?> ttransportClass = Class.forName(TTRANSPORT_CLASS);
+                closeTransport(transport, ttransportClass);
+            } catch (Exception e) {
+                LOG.debug("Error closing Thrift transport", e);
+            }
+            transport = null;
+        }
+        thriftClient = null;
+        connected = false;
+    }
+
+    private void cleanupOnFailure() {
+        if (transport != null) {
+            try {
+                Class<?> ttransportClass = Class.forName(TTRANSPORT_CLASS);
+                closeTransport(transport, ttransportClass);
+            } catch (Exception e) {
+                LOG.debug("Error during cleanup: {}", e.getMessage());
+            }
+            transport = null;
+        }
+        thriftClient = null;
+        connected = false;
+    }
+
+    private void closeTransport(Object t, Class<?> ttransportClass) {
+        try {
+            Method isOpenMethod = ttransportClass.getMethod("isOpen");
+            Boolean isOpen = (Boolean) isOpenMethod.invoke(t);
+            if (Boolean.TRUE.equals(isOpen)) {
+                Method closeMethod = ttransportClass.getMethod("close");
+                closeMethod.invoke(t);
+            }
+        } catch (Exception e) {
+            LOG.debug("Error closing transport: {}", e.getMessage());
+        }
+    }
+
+    private void cleanupTransport(Object t, Class<?> ttransportClass) {
+        try {
+            closeTransport(t, ttransportClass);
+        } catch (Exception e) {
+            LOG.debug("Error cleaning up transport: {}", e.getMessage());
+        }
+    }
+
+    public boolean isConnected() {
+        if (!connected || transport == null) {
+            return false;
+        }
+        try {
+            Class<?> ttransportClass = Class.forName(TTRANSPORT_CLASS);
+            Method isOpenMethod = ttransportClass.getMethod("isOpen");
+            return (Boolean) isOpenMethod.invoke(transport);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private void ensureConnected() {
+        if (!connected || thriftClient == null) {
+            throw new IllegalStateException("Not connected to HMS");
+        }
+    }
+
+    public static class DatabaseInfo {
+        public String name;
+        public String locationUri;
+    }
+
+    public static class TableInfo {
+        public String dbName;
+        public String tableName;
+        public String tableType;
+        public String location;
+
+        public boolean isManaged() {
+            return tableType == null || "MANAGED_TABLE".equalsIgnoreCase(tableType);
+        }
+    }
+
+    public static class NotificationEventInfo {
+        public long eventId;
+        public String eventType;
+        public String dbName;
+        public String tableName;
+        public String message;
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
@@ -390,15 +390,14 @@ public class HMSClientWrapper implements AutoCloseable {
 
     public TableInfo getTable(String dbName, String tableName) throws Exception {
         ensureConnected();
-        Method method = thriftClient.getClass().getMethod("get_table", String.class, String.class);
-        Object table = method.invoke(thriftClient, dbName, tableName);
 
+        Object table = fetchTable(dbName, tableName);
         if (table == null) {
             return null;
         }
 
         TableInfo info = new TableInfo();
-        info.dbName = (String) table.getClass().getMethod("getDbName").invoke(table);
+        info.dbName    = (String) table.getClass().getMethod("getDbName").invoke(table);
         info.tableName = (String) table.getClass().getMethod("getTableName").invoke(table);
         info.tableType = (String) table.getClass().getMethod("getTableType").invoke(table);
 
@@ -408,6 +407,57 @@ public class HMSClientWrapper implements AutoCloseable {
         }
 
         return info;
+    }
+
+    /**
+     * Fetch a Table via the newest available HMS Thrift signature.
+     *
+     * Hive 4 HMS filters out tables whose {@code transactional_properties=insert_only}
+     * (and full-ACID) unless the caller declares
+     * {@link org.apache.hadoop.hive.metastore.api.ClientCapability#INSERT_ONLY_TABLES}.
+     * The legacy two-arg {@code get_table(String, String)} has no way to pass
+     * capabilities, so on Hive 4 it server-side NPEs for those tables and surfaces
+     * client-side as an {@link java.lang.reflect.InvocationTargetException} with a
+     * null message.
+     *
+     * Strategy (mirrors {@code wrapWithSASL} 7-arg-vs-6-arg drift tolerance):
+     *   1. Try {@code get_table_req(GetTableRequest)} (Hive 3.0+) with
+     *      {@code ClientCapabilities([INSERT_ONLY_TABLES])} so ACID v2 tables are
+     *      returned. Unwrap {@code GetTableResult.getTable()}.
+     *   2. Fall back to legacy {@code get_table(String, String)} on older HMS that
+     *      doesn't expose the v2 signature.
+     */
+    private Object fetchTable(String dbName, String tableName) throws Exception {
+        try {
+            Class<?> reqClass  = Class.forName("org.apache.hadoop.hive.metastore.api.GetTableRequest");
+            Class<?> capsClass = Class.forName("org.apache.hadoop.hive.metastore.api.ClientCapabilities");
+            Class<?> capClass  = Class.forName("org.apache.hadoop.hive.metastore.api.ClientCapability");
+
+            // ClientCapabilities(List<ClientCapability>) with INSERT_ONLY_TABLES.
+            Object insertOnlyCap = capClass.getMethod("valueOf", String.class).invoke(null, "INSERT_ONLY_TABLES");
+            java.util.List<Object> capList = new java.util.ArrayList<>();
+            capList.add(insertOnlyCap);
+            Object caps = capsClass.getConstructor(java.util.List.class).newInstance(capList);
+
+            // GetTableRequest(dbName, tblName) + setCapabilities(...).
+            Object req = reqClass.getConstructor(String.class, String.class).newInstance(dbName, tableName);
+            reqClass.getMethod("setCapabilities", capsClass).invoke(req, caps);
+
+            Method getTableReq = thriftClient.getClass().getMethod("get_table_req", reqClass);
+            Object resp = getTableReq.invoke(thriftClient, req);
+
+            if (resp == null) {
+                return null;
+            }
+            return resp.getClass().getMethod("getTable").invoke(resp);
+        } catch (ClassNotFoundException | NoSuchMethodException olderHms) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("get_table_req not available on this HMS; falling back to legacy get_table: {}",
+                          olderHms.toString());
+            }
+            Method legacy = thriftClient.getClass().getMethod("get_table", String.class, String.class);
+            return legacy.invoke(thriftClient, dbName, tableName);
+        }
     }
 
     public long getCurrentNotificationEventId() throws Exception {

--- a/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/HMSClientWrapper.java
@@ -396,6 +396,119 @@ public class HMSClientWrapper implements AutoCloseable {
             return null;
         }
 
+        return toTableInfo(table);
+    }
+
+    /**
+     * Batch-fetch a set of tables from a single database in one Thrift round-trip.
+     *
+     * At scale (hundreds of thousands to millions of tables) the per-table
+     * {@code get_table} call is the wall-clock bottleneck of the initial full
+     * sync: 1 RPC + 1 HMS DB query per table. HMS exposes a bulk endpoint that
+     * returns many tables in one shot; using it collapses N Thrift round-trips
+     * to {@code ceil(N / batchSize)}, typically a 100-200x reduction.
+     *
+     * <p>Strategy (mirrors {@link #fetchTable}'s try-newer-fall-back-to-older
+     * drift tolerance):
+     * <ol>
+     *   <li>Try {@code get_table_objects_by_name_req(GetTablesRequest)} (Hive 3.0+)
+     *       with {@code ClientCapabilities([INSERT_ONLY_TABLES])} so Hive 4 ACID
+     *       v2 tables are returned. Unwrap {@code GetTablesResult.getTables()}.</li>
+     *   <li>Fall back to legacy {@code get_table_objects_by_name(String, List<String>)}
+     *       (available on all supported HMS versions but without capability
+     *       negotiation — server-side filters out insert-only ACID tables on
+     *       Hive 4).</li>
+     *   <li>Last-resort fall back to per-table {@link #fetchTable} — slow, but
+     *       correct on any HMS that doesn't expose either bulk API.</li>
+     * </ol>
+     *
+     * <p>Tables that don't exist (or that Hive filters out) are simply absent
+     * from the returned list; the caller is expected to tolerate a shorter
+     * response than the requested name list.
+     */
+    public List<TableInfo> getTables(String dbName, List<String> tableNames) throws Exception {
+        ensureConnected();
+
+        if (tableNames == null || tableNames.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<Object> tables = fetchTables(dbName, tableNames);
+        List<TableInfo> results = new ArrayList<>(tables.size());
+        for (Object table : tables) {
+            if (table != null) {
+                try {
+                    results.add(toTableInfo(table));
+                } catch (Exception e) {
+                    LOG.warn("Failed to convert Thrift Table object for db={}: {}", dbName, e.getMessage());
+                }
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Fetch tables via the newest available bulk Thrift signature.
+     * See {@link #getTables(String, List)} javadoc for the fallback strategy.
+     */
+    @SuppressWarnings("unchecked")
+    private List<Object> fetchTables(String dbName, List<String> tableNames) throws Exception {
+        // Strategy 1: get_table_objects_by_name_req(GetTablesRequest) with capabilities.
+        try {
+            Class<?> reqClass  = Class.forName("org.apache.hadoop.hive.metastore.api.GetTablesRequest");
+            Class<?> capsClass = Class.forName("org.apache.hadoop.hive.metastore.api.ClientCapabilities");
+            Class<?> capClass  = Class.forName("org.apache.hadoop.hive.metastore.api.ClientCapability");
+
+            Object insertOnlyCap = capClass.getMethod("valueOf", String.class).invoke(null, "INSERT_ONLY_TABLES");
+            java.util.List<Object> capList = new java.util.ArrayList<>();
+            capList.add(insertOnlyCap);
+            Object caps = capsClass.getConstructor(java.util.List.class).newInstance(capList);
+
+            Object req = reqClass.getConstructor(String.class).newInstance(dbName);
+            reqClass.getMethod("setTblNames", java.util.List.class).invoke(req, tableNames);
+            reqClass.getMethod("setCapabilities", capsClass).invoke(req, caps);
+
+            Method getTablesReq = thriftClient.getClass().getMethod("get_table_objects_by_name_req", reqClass);
+            Object resp = getTablesReq.invoke(thriftClient, req);
+            if (resp == null) {
+                return new ArrayList<>();
+            }
+            Object tables = resp.getClass().getMethod("getTables").invoke(resp);
+            return tables != null ? new ArrayList<>((List<Object>) tables) : new ArrayList<>();
+        } catch (ClassNotFoundException | NoSuchMethodException newerNotAvailable) {
+            LOG.debug("get_table_objects_by_name_req not available; trying legacy bulk API: {}",
+                     newerNotAvailable.toString());
+        }
+
+        // Strategy 2: legacy get_table_objects_by_name(String, List<String>).
+        try {
+            Method legacyBulk = thriftClient.getClass().getMethod(
+                    "get_table_objects_by_name", String.class, java.util.List.class);
+            Object result = legacyBulk.invoke(thriftClient, dbName, tableNames);
+            if (result instanceof List) {
+                return new ArrayList<>((List<Object>) result);
+            }
+        } catch (NoSuchMethodException legacyNotAvailable) {
+            LOG.debug("get_table_objects_by_name not available; falling back to per-table fetch: {}",
+                     legacyNotAvailable.toString());
+        }
+
+        // Strategy 3: worst-case per-table fetch. Correct but slow.
+        List<Object> results = new ArrayList<>(tableNames.size());
+        for (String name : tableNames) {
+            try {
+                Object t = fetchTable(dbName, name);
+                if (t != null) {
+                    results.add(t);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to fetch table {}.{} in per-table fallback: {}", dbName, name, e.getMessage());
+            }
+        }
+        return results;
+    }
+
+    private TableInfo toTableInfo(Object table) throws Exception {
         TableInfo info = new TableInfo();
         info.dbName    = (String) table.getClass().getMethod("getDbName").invoke(table);
         info.tableName = (String) table.getClass().getMethod("getTableName").invoke(table);
@@ -405,7 +518,6 @@ public class HMSClientWrapper implements AutoCloseable {
         if (sd != null) {
             info.location = (String) sd.getClass().getMethod("getLocation").invoke(sd);
         }
-
         return info;
     }
 

--- a/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
@@ -1,0 +1,1028 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.rms;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.biz.RMSMgr;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.apache.ranger.common.PropertiesUtil;
+import org.apache.ranger.rms.HMSClientWrapper.DatabaseInfo;
+import org.apache.ranger.rms.HMSClientWrapper.TableInfo;
+import org.apache.ranger.rms.HMSClientWrapper.NotificationEventInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * RangerRMSPollerService polls HMS (Hive Metastore) for notification events
+ * and updates RMS mappings accordingly.
+ *
+ * RMS polls HMS via Thrift to discover table/database metadata and their
+ * storage locations, eliminating the need for an HMS listener configuration.
+ *
+ * Configuration properties (in ranger-admin-site.xml):
+ * - ranger.rms.enabled: Enable/disable RMS (default: false)
+ * - ranger.rms.hms.uri: HMS Thrift URI (e.g., thrift://hms-host:9083)
+ * - ranger.rms.polling.notifications.frequency.ms: Polling interval (default: 30000)
+ * - ranger.rms.hive.service.name: Hive service name in Ranger
+ * - ranger.rms.hdfs.service.name: HDFS service name in Ranger
+ * - ranger.rms.ozone.service.name: Ozone service name in Ranger
+ * - ranger.rms.s3.service.name: S3 service name in Ranger
+ * - ranger.rms.supported.uri.schemes: Supported URI schemes (default: hdfs,o3fs,ofs,s3a)
+ * - ranger.rms.map.managed.tables: Track managed tables (default: true)
+ */
+@Service
+@Lazy(false)
+public class RangerRMSPollerService {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerRMSPollerService.class);
+
+    private static final String CONFIG_RMS_ENABLED = "ranger.rms.enabled";
+    private static final String CONFIG_HMS_URI = "ranger.rms.hms.uri";
+    private static final String CONFIG_POLLING_INTERVAL = "ranger.rms.polling.notifications.frequency.ms";
+    private static final String CONFIG_HIVE_SERVICE_NAME = "ranger.rms.hive.service.name";
+    private static final String CONFIG_HDFS_SERVICE_NAME = "ranger.rms.hdfs.service.name";
+    private static final String CONFIG_OZONE_SERVICE_NAME = "ranger.rms.ozone.service.name";
+    private static final String CONFIG_S3_SERVICE_NAME = "ranger.rms.s3.service.name";
+    private static final String CONFIG_SUPPORTED_URI_SCHEMES = "ranger.rms.supported.uri.schemes";
+    private static final String CONFIG_MAP_MANAGED_TABLES = "ranger.rms.map.managed.tables";
+    private static final String CONFIG_INITIAL_FULL_SYNC = "ranger.rms.initial.full.sync";
+    private static final String CONFIG_HMS_SASL_ENABLED = "ranger.rms.hms.sasl.enabled";
+    private static final String CONFIG_HMS_KERBEROS_PRINCIPAL = "ranger.rms.hms.kerberos.principal";
+    private static final String CONFIG_HMS_SSL_ENABLED = "ranger.rms.hms.ssl.enabled";
+    private static final String CONFIG_HMS_TRUSTSTORE_PATH = "ranger.rms.hms.ssl.truststore.path";
+    private static final String CONFIG_HMS_TRUSTSTORE_PASSWORD = "ranger.rms.hms.ssl.truststore.password";
+    // Client-side principal/keytab the RMS poller logs in as when SASL is enabled.
+    // Falls back to ranger.admin.kerberos.* if not specified.
+    private static final String CONFIG_HMS_CLIENT_PRINCIPAL = "ranger.rms.hms.kerberos.client.principal";
+    private static final String CONFIG_HMS_CLIENT_KEYTAB = "ranger.rms.hms.kerberos.client.keytab";
+    private static final String CONFIG_RANGER_ADMIN_PRINCIPAL = "ranger.admin.kerberos.principal";
+    private static final String CONFIG_RANGER_ADMIN_KEYTAB = "ranger.admin.kerberos.keytab";
+
+    private static final String DEFAULT_HIVE_SERVICE_NAME = "hive";
+    private static final String DEFAULT_HDFS_SERVICE_NAME = "hdfs";
+    private static final String DEFAULT_OZONE_SERVICE_NAME = "ozone";
+    private static final String DEFAULT_S3_SERVICE_NAME = "s3";
+    private static final String DEFAULT_SUPPORTED_URI_SCHEMES = "hdfs,o3fs,ofs,s3a";
+    private static final long DEFAULT_POLLING_INTERVAL_MS = 30000;
+
+    private static final String EVENT_CREATE_DATABASE = "CREATE_DATABASE";
+    private static final String EVENT_DROP_DATABASE = "DROP_DATABASE";
+    private static final String EVENT_ALTER_DATABASE = "ALTER_DATABASE";
+    private static final String EVENT_CREATE_TABLE = "CREATE_TABLE";
+    private static final String EVENT_DROP_TABLE = "DROP_TABLE";
+    private static final String EVENT_ALTER_TABLE = "ALTER_TABLE";
+    private static final String EVENT_RENAME_TABLE = "RENAME_TABLE";
+
+    private static final String HIVE_RESOURCE_DATABASE = "database";
+    private static final String HIVE_RESOURCE_TABLE = "table";
+    private static final String HDFS_RESOURCE_PATH = "path";
+    private static final String OZONE_RESOURCE_VOLUME = "volume";
+    private static final String OZONE_RESOURCE_BUCKET = "bucket";
+    private static final String OZONE_RESOURCE_KEY = "key";
+    private static final String S3_RESOURCE_BUCKET = "bucket";
+    private static final String S3_RESOURCE_PATH = "path";
+
+    @Autowired
+    private RMSMgr rmsMgr;
+
+    private boolean enabled;
+    private String hmsUri;
+    private long pollingIntervalMs;
+    private String hiveServiceName;
+    private String hdfsServiceName;
+    private String ozoneServiceName;
+    private String s3ServiceName;
+    private Set<String> supportedUriSchemes;
+    private boolean mapManagedTables;
+    private boolean initialFullSync;
+    private boolean hmsSaslEnabled;
+    private String hmsKerberosPrincipal;
+    private String hmsClientPrincipal;
+    private String hmsClientKeytab;
+    private boolean hmsSslEnabled;
+    private String hmsTruststorePath;
+    private String hmsTruststorePassword;
+    private boolean kerberosLoginAttempted = false;
+
+    private ScheduledExecutorService scheduler;
+    private HMSClientWrapper hmsClient;
+    private AtomicLong lastEventId = new AtomicLong(-1);
+    private AtomicBoolean isRunning = new AtomicBoolean(false);
+    private AtomicBoolean fullSyncCompleted = new AtomicBoolean(false);
+
+    @PostConstruct
+    public void init() {
+        LOG.info("==> RangerRMSPollerService.init()");
+
+        loadConfiguration();
+
+        LOG.info("RMS Poller Configuration:");
+        LOG.info("  enabled: {}", enabled);
+        LOG.info("  hmsUri: {}", hmsUri);
+        LOG.info("  pollingIntervalMs: {}", pollingIntervalMs);
+        LOG.info("  hiveServiceName: {}", hiveServiceName);
+        LOG.info("  hdfsServiceName: {}", hdfsServiceName);
+        LOG.info("  ozoneServiceName: {}", ozoneServiceName);
+        LOG.info("  s3ServiceName: {}", s3ServiceName);
+        LOG.info("  supportedUriSchemes: {}", supportedUriSchemes);
+        LOG.info("  mapManagedTables: {}", mapManagedTables);
+        LOG.info("  initialFullSync: {}", initialFullSync);
+        LOG.info("  hmsSaslEnabled: {}", hmsSaslEnabled);
+        LOG.info("  hmsKerberosPrincipal: {}", hmsKerberosPrincipal);
+        LOG.info("  hmsClientPrincipal:   {}", hmsClientPrincipal);
+        LOG.info("  hmsClientKeytab:      {}", hmsClientKeytab);
+        LOG.info("  hmsSslEnabled: {}", hmsSslEnabled);
+        LOG.info("  hmsTruststorePath: {}", hmsTruststorePath);
+
+        if (enabled) {
+            restoreState();
+            startPolling();
+        } else {
+            LOG.info("RMS is disabled. Polling will not start.");
+        }
+
+        LOG.info("<== RangerRMSPollerService.init()");
+    }
+
+    private void loadConfiguration() {
+        enabled = PropertiesUtil.getBooleanProperty(CONFIG_RMS_ENABLED, false);
+        hmsUri = PropertiesUtil.getProperty(CONFIG_HMS_URI, "");
+        pollingIntervalMs = PropertiesUtil.getLongProperty(CONFIG_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL_MS);
+        hiveServiceName = PropertiesUtil.getProperty(CONFIG_HIVE_SERVICE_NAME, DEFAULT_HIVE_SERVICE_NAME);
+        hdfsServiceName = PropertiesUtil.getProperty(CONFIG_HDFS_SERVICE_NAME, DEFAULT_HDFS_SERVICE_NAME);
+        ozoneServiceName = PropertiesUtil.getProperty(CONFIG_OZONE_SERVICE_NAME, DEFAULT_OZONE_SERVICE_NAME);
+        s3ServiceName = PropertiesUtil.getProperty(CONFIG_S3_SERVICE_NAME, DEFAULT_S3_SERVICE_NAME);
+        mapManagedTables = PropertiesUtil.getBooleanProperty(CONFIG_MAP_MANAGED_TABLES, true);
+        initialFullSync = PropertiesUtil.getBooleanProperty(CONFIG_INITIAL_FULL_SYNC, true);
+
+        hmsSaslEnabled = PropertiesUtil.getBooleanProperty(CONFIG_HMS_SASL_ENABLED, false);
+        hmsKerberosPrincipal = PropertiesUtil.getProperty(CONFIG_HMS_KERBEROS_PRINCIPAL, "");
+        hmsSslEnabled = PropertiesUtil.getBooleanProperty(CONFIG_HMS_SSL_ENABLED, false);
+        hmsTruststorePath = PropertiesUtil.getProperty(CONFIG_HMS_TRUSTSTORE_PATH, "");
+        hmsTruststorePassword = PropertiesUtil.getProperty(CONFIG_HMS_TRUSTSTORE_PASSWORD, "");
+
+        // Client identity for the SASL/Kerberos handshake. Prefer RMS-specific keys,
+        // fall back to ranger.admin.kerberos.{principal,keytab} so a single set of
+        // admin credentials suffices in the common case.
+        hmsClientPrincipal = PropertiesUtil.getProperty(CONFIG_HMS_CLIENT_PRINCIPAL, "");
+        if (StringUtils.isBlank(hmsClientPrincipal)) {
+            hmsClientPrincipal = PropertiesUtil.getProperty(CONFIG_RANGER_ADMIN_PRINCIPAL, "");
+        }
+        hmsClientKeytab = PropertiesUtil.getProperty(CONFIG_HMS_CLIENT_KEYTAB, "");
+        if (StringUtils.isBlank(hmsClientKeytab)) {
+            hmsClientKeytab = PropertiesUtil.getProperty(CONFIG_RANGER_ADMIN_KEYTAB, "");
+        }
+
+        String schemes = PropertiesUtil.getProperty(CONFIG_SUPPORTED_URI_SCHEMES, DEFAULT_SUPPORTED_URI_SCHEMES);
+        supportedUriSchemes = new HashSet<>();
+        for (String scheme : schemes.split(",")) {
+            supportedUriSchemes.add(scheme.trim().toLowerCase());
+        }
+    }
+
+    private void restoreState() {
+        try {
+            LOG.info("Attempting to restore RMS poller state from database...");
+            long persistedEventId = rmsMgr.getLastProcessedEventId();
+            boolean hasMappings = rmsMgr.hasExistingMappings();
+            LOG.info("DB state: persistedEventId={}, hasMappings={}", persistedEventId, hasMappings);
+
+            if (persistedEventId >= 0 && hasMappings) {
+                lastEventId.set(persistedEventId);
+                fullSyncCompleted.set(true);
+                LOG.info("Restored RMS poller state: lastEventId={}, skipping full sync", persistedEventId);
+            } else {
+                LOG.info("No persisted RMS state found (eventId={}, hasMappings={}), will perform full sync", persistedEventId, hasMappings);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to restore RMS poller state, will perform full sync", e);
+        }
+    }
+
+    @PreDestroy
+    public void cleanup() {
+        LOG.info("==> RangerRMSPollerService.cleanup()");
+        stopPolling();
+        persistState();
+        closeHMSClient();
+        LOG.info("<== RangerRMSPollerService.cleanup()");
+    }
+
+    private void persistState() {
+        try {
+            long eventId = lastEventId.get();
+            if (eventId >= 0) {
+                rmsMgr.saveLastProcessedEventId(eventId);
+                LOG.info("Persisted RMS poller state: lastEventId={}", eventId);
+            } else {
+                LOG.debug("Not persisting state: eventId={}", eventId);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to persist RMS poller state (eventId={})", lastEventId.get(), e);
+        }
+    }
+
+    private void startPolling() {
+        LOG.info("Starting RMS HMS polling with interval: {}ms", pollingIntervalMs);
+        
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "RMS-HMS-Poller");
+            t.setDaemon(true);
+            return t;
+        });
+
+        // Initial delay to allow Ranger Admin to fully start
+        long initialDelay = 10000;
+
+        scheduler.scheduleAtFixedRate(this::pollHMS, initialDelay, pollingIntervalMs, TimeUnit.MILLISECONDS);
+        LOG.info("RMS HMS polling scheduled with initial delay: {}ms, interval: {}ms", initialDelay, pollingIntervalMs);
+    }
+
+    private void stopPolling() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+            try {
+                if (!scheduler.awaitTermination(30, TimeUnit.SECONDS)) {
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void pollHMS() {
+        if (!isRunning.compareAndSet(false, true)) {
+            LOG.debug("Previous polling cycle still running, skipping...");
+            return;
+        }
+
+        try {
+            LOG.debug("==> pollHMS()");
+
+            HMSClientWrapper client = getHMSClient();
+            if (client == null) {
+                LOG.warn("Failed to get HMS client, skipping poll cycle");
+                return;
+            }
+
+            // Perform full sync on first run if enabled
+            if (initialFullSync && !fullSyncCompleted.get()) {
+                LOG.info("Performing initial full sync from HMS...");
+                FullSyncStats stats = performFullSync(client);
+
+                if (stats.isFullyFailed()) {
+                    // Every mapping write failed (e.g. schema patch missing,
+                    // DB connection broken). Don't flip fullSyncCompleted to
+                    // true — leave it false so a future trigger / next cycle
+                    // retries once the underlying issue is fixed. Also keep
+                    // lastEventId where it was so we don't silently skip past
+                    // events that should have produced mappings.
+                    LOG.error("Full sync attempted {} mappings, all failed. "
+                            + "Leaving fullSyncCompleted=false; check Admin DB / schema patches.",
+                            stats.attempted);
+                    return;
+                }
+
+                fullSyncCompleted.set(true);
+
+                long currentId = client.getCurrentNotificationEventId();
+                lastEventId.set(currentId);
+                persistState();
+                LOG.info("Full sync completed (attempted={}, failed={}). Current event ID: {}",
+                        stats.attempted, stats.failed, lastEventId.get());
+                return;
+            }
+
+            // Get current event ID
+            long currentEventId = client.getCurrentNotificationEventId();
+
+            if (lastEventId.get() < 0) {
+                // First time, just record the event ID
+                lastEventId.set(currentEventId);
+                LOG.info("Initialized last event ID: {}", lastEventId.get());
+                return;
+            }
+
+            if (currentEventId == lastEventId.get()) {
+                LOG.debug("No new events since last poll (eventId={})", currentEventId);
+                return;
+            }
+
+            // Fetch notification events
+            LOG.info("Fetching HMS notifications from eventId {} to {}", lastEventId.get(), currentEventId);
+            
+            try {
+                List<NotificationEventInfo> events = client.getNextNotification(lastEventId.get(), 1000);
+
+                if (events != null && !events.isEmpty()) {
+                    LOG.info("Processing {} HMS notification events", events.size());
+
+                    for (NotificationEventInfo event : events) {
+                        processNotificationEvent(client, event);
+                        lastEventId.set(event.eventId);
+                    }
+                    persistState();
+                } else {
+                    // HMS reports a higher current event ID than we've processed
+                    // but returns no events for the requested range. This is
+                    // typically a real gap (events trimmed/expired between two
+                    // polls) rather than a transient error, but we cannot tell
+                    // for sure. Log loudly and skip ahead to currentEventId so
+                    // the poller does not get permanently stuck; subsequent
+                    // events will continue to be processed.
+                    LOG.warn("No notification events returned for range ({}, {}], "
+                            + "advancing watermark to {} (possible event gap on HMS)",
+                            lastEventId.get(), currentEventId, currentEventId);
+                    lastEventId.set(currentEventId);
+                    persistState();
+                }
+            } catch (Exception e) {
+                // On fetch / processing error keep the watermark unchanged so
+                // the next cycle retries the same range. Advancing here would
+                // permanently skip events and silently corrupt RMS state.
+                LOG.warn("Error fetching notifications from eventId {} (current={}). "
+                        + "Watermark unchanged; will retry next cycle.",
+                        lastEventId.get(), currentEventId, e);
+            }
+            LOG.debug("<== pollHMS() processed events up to eventId={}", lastEventId.get());
+
+        } catch (Exception e) {
+            LOG.error("Error polling HMS for notifications", e);
+            closeHMSClient();
+        } finally {
+            isRunning.set(false);
+        }
+    }
+
+    /**
+     * Result summary of a full-sync pass: how many mappings were attempted and
+     * how many failed. Used by the caller to decide whether the sync truly
+     * completed (e.g. don't mark fullSyncCompleted=true if every mapping
+     * failed — that usually indicates a systemic problem like a missing schema
+     * patch that we want to surface instead of silently flipping to "done").
+     */
+    static final class FullSyncStats {
+        int attempted;
+        int failed;
+
+        boolean isFullyFailed() {
+            return attempted > 0 && failed >= attempted;
+        }
+    }
+
+    private FullSyncStats performFullSync(HMSClientWrapper client) throws Exception {
+        LOG.info("==> performFullSync()");
+
+        FullSyncStats stats = new FullSyncStats();
+
+        try {
+            List<String> databases = client.getAllDatabases();
+            LOG.info("Found {} databases in HMS", databases.size());
+
+            for (String dbName : databases) {
+                try {
+                    if ("sys".equalsIgnoreCase(dbName) || "information_schema".equalsIgnoreCase(dbName)) {
+                        continue;
+                    }
+
+                    DatabaseInfo db = client.getDatabase(dbName);
+                    if (db != null) {
+                        String dbLocation = db.locationUri;
+                        if (StringUtils.isNotBlank(dbLocation) && isSupportedLocation(dbLocation)) {
+                            stats.attempted++;
+                            if (!processCreateDatabase(dbName, dbLocation)) {
+                                stats.failed++;
+                            }
+                        }
+                    }
+
+                    List<String> tables = client.getAllTables(dbName);
+                    LOG.info("Database {}: found {} tables", dbName, tables.size());
+
+                    for (String tableName : tables) {
+                        try {
+                            TableInfo table = client.getTable(dbName, tableName);
+                            stats.attempted++;
+                            if (!processTable(table)) {
+                                stats.failed++;
+                            }
+                        } catch (Exception e) {
+                            stats.failed++;
+                            LOG.warn("Error processing table {}.{}: {}", dbName, tableName, e.getMessage());
+                        }
+                    }
+
+                } catch (Exception e) {
+                    LOG.warn("Error processing database {}: {}", dbName, e.getMessage());
+                }
+            }
+
+        } catch (Exception e) {
+            LOG.error("Error during full sync", e);
+            throw e;
+        }
+
+        LOG.info("<== performFullSync() attempted={}, failed={}", stats.attempted, stats.failed);
+        return stats;
+    }
+
+    private void processNotificationEvent(HMSClientWrapper client, NotificationEventInfo event) {
+        String eventType = event.eventType;
+        String dbName = event.dbName;
+        String tableName = event.tableName;
+
+        LOG.debug("Processing event: type={}, db={}, table={}, eventId={}", 
+                  eventType, dbName, tableName, event.eventId);
+
+        try {
+            switch (eventType) {
+                case EVENT_CREATE_DATABASE:
+                    handleCreateDatabase(client, dbName);
+                    break;
+
+                case EVENT_DROP_DATABASE:
+                    handleDropDatabase(dbName);
+                    break;
+
+                case EVENT_ALTER_DATABASE:
+                    handleAlterDatabase(client, dbName);
+                    break;
+
+                case EVENT_CREATE_TABLE:
+                    handleCreateTable(client, dbName, tableName);
+                    break;
+
+                case EVENT_DROP_TABLE:
+                    handleDropTable(dbName, tableName);
+                    break;
+
+                case EVENT_ALTER_TABLE:
+                    handleAlterTable(client, dbName, tableName);
+                    break;
+
+                case EVENT_RENAME_TABLE:
+                    handleRenameTable(client, event);
+                    break;
+
+                default:
+                    LOG.debug("Ignoring event type: {}", eventType);
+            }
+        } catch (Exception e) {
+            LOG.error("Error processing event: type={}, db={}, table={}", eventType, dbName, tableName, e);
+        }
+    }
+
+    private void handleCreateDatabase(HMSClientWrapper client, String dbName) throws Exception {
+        DatabaseInfo db = client.getDatabase(dbName);
+        if (db != null) {
+            String location = db.locationUri;
+            
+            if (StringUtils.isNotBlank(location) && isSupportedLocation(location)) {
+                processCreateDatabase(dbName, location);
+            }
+        }
+    }
+
+    private void handleDropDatabase(String dbName) {
+        LOG.info("Processing DROP_DATABASE: {}", dbName);
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveDatabaseResource(dbName);
+            rmsMgr.deleteMappingsByHlResource(hiveServiceName, hiveResource);
+            LOG.info("Deleted RMS mappings for dropped database: {}", dbName);
+        } catch (Exception e) {
+            LOG.error("Error deleting mappings for dropped database: {}", dbName, e);
+        }
+    }
+
+    private void handleAlterDatabase(HMSClientWrapper client, String dbName) throws Exception {
+        DatabaseInfo db = client.getDatabase(dbName);
+        if (db != null) {
+            String location = db.locationUri;
+            
+            if (StringUtils.isNotBlank(location) && isSupportedLocation(location)) {
+                processCreateDatabase(dbName, location);
+            }
+        }
+    }
+
+    private void handleCreateTable(HMSClientWrapper client, String dbName, String tableName) throws Exception {
+        TableInfo table = client.getTable(dbName, tableName);
+        processTable(table);
+    }
+
+    private void handleDropTable(String dbName, String tableName) {
+        LOG.info("Processing DROP_TABLE: {}.{}", dbName, tableName);
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveTableResource(dbName, tableName);
+            rmsMgr.deleteMappingsByHlResource(hiveServiceName, hiveResource);
+            LOG.info("Deleted RMS mappings for dropped table: {}.{}", dbName, tableName);
+        } catch (Exception e) {
+            LOG.error("Error deleting mappings for dropped table: {}.{}", dbName, tableName, e);
+        }
+    }
+
+    private void handleAlterTable(HMSClientWrapper client, String dbName, String tableName) throws Exception {
+        TableInfo table = client.getTable(dbName, tableName);
+        processTable(table);
+    }
+
+    private void handleRenameTable(HMSClientWrapper client, NotificationEventInfo event) {
+        String dbName = event.dbName;
+        String oldTableName = event.tableName;
+
+        LOG.info("Processing RENAME_TABLE: {}.{}", dbName, oldTableName);
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> oldHiveResource = createHiveTableResource(dbName, oldTableName);
+            rmsMgr.deleteMappingsByHlResource(hiveServiceName, oldHiveResource);
+            LOG.info("Deleted old RMS mappings for renamed table: {}.{}", dbName, oldTableName);
+        } catch (Exception e) {
+            LOG.error("Error deleting old mappings for renamed table: {}.{}", dbName, oldTableName, e);
+        }
+
+        String newTableName = extractNewTableName(event.message);
+        if (StringUtils.isBlank(newTableName)) {
+            LOG.warn("Could not extract new table name from RENAME_TABLE event for {}.{}, skipping new mapping creation", dbName, oldTableName);
+            return;
+        }
+
+        LOG.info("RENAME_TABLE: {}.{} -> {}.{}", dbName, oldTableName, dbName, newTableName);
+
+        try {
+            TableInfo newTable = client.getTable(dbName, newTableName);
+            processTable(newTable);
+        } catch (Exception e) {
+            LOG.error("Error creating new mappings for renamed table: {}.{}", dbName, newTableName, e);
+        }
+    }
+
+    /**
+     * Extract the new table name from a RENAME_TABLE event message JSON.
+     * Hive 4 message format: {"table":{"tableName":"new_name","dbName":"mydb",...}}
+     */
+    private String extractNewTableName(String message) {
+        if (StringUtils.isBlank(message)) {
+            return null;
+        }
+
+        try {
+            int tableObjIdx = message.indexOf("\"table\"");
+            if (tableObjIdx < 0) {
+                tableObjIdx = message.indexOf("\"tableObjAfterRename\"");
+            }
+            if (tableObjIdx < 0) {
+                return null;
+            }
+
+            String afterTableKey = message.substring(tableObjIdx);
+            int tableNameIdx = afterTableKey.indexOf("\"tableName\"");
+            if (tableNameIdx < 0) {
+                return null;
+            }
+
+            String afterTableName = afterTableKey.substring(tableNameIdx + "\"tableName\"".length());
+            int colonIdx = afterTableName.indexOf(':');
+            if (colonIdx < 0) {
+                return null;
+            }
+
+            String afterColon = afterTableName.substring(colonIdx + 1).trim();
+            if (afterColon.startsWith("\"")) {
+                int endQuote = afterColon.indexOf('"', 1);
+                if (endQuote > 0) {
+                    return afterColon.substring(1, endQuote);
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to parse RENAME_TABLE message: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
+    private boolean processTable(TableInfo table) {
+        if (table == null) {
+            return true;
+        }
+
+        String dbName = table.dbName;
+        String tableName = table.tableName;
+        String location = table.location;
+        boolean isManaged = table.isManaged();
+
+        if (!mapManagedTables && isManaged) {
+            LOG.debug("Skipping managed table: {}.{}", dbName, tableName);
+            return true;
+        }
+
+        if (StringUtils.isBlank(location) || !isSupportedLocation(location)) {
+            LOG.debug("Skipping table with unsupported location: {}.{} -> {}", dbName, tableName, location);
+            return true;
+        }
+
+        LOG.info("Processing table: {}.{} -> {} (managed={})", dbName, tableName, location, isManaged);
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveTableResource(dbName, tableName);
+            String llServiceName = getStorageServiceName(location);
+            Map<String, RangerPolicy.RangerPolicyResource> storageResource = createStorageResource(location);
+
+            if (llServiceName != null && storageResource != null) {
+                rmsMgr.createOrUpdateMapping(hiveServiceName, hiveResource, llServiceName, storageResource, location);
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.error("Failed to create mapping for table {}.{}", dbName, tableName, e);
+            return false;
+        }
+    }
+
+    private boolean processCreateDatabase(String dbName, String location) {
+        LOG.info("Processing database: {} -> {}", dbName, location);
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveDatabaseResource(dbName);
+            String llServiceName = getStorageServiceName(location);
+            Map<String, RangerPolicy.RangerPolicyResource> storageResource = createStorageResource(location);
+
+            if (llServiceName != null && storageResource != null) {
+                rmsMgr.createOrUpdateMapping(hiveServiceName, hiveResource, llServiceName, storageResource, location);
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.error("Failed to create mapping for database {}", dbName, e);
+            return false;
+        }
+    }
+
+    private boolean isSupportedLocation(String location) {
+        if (StringUtils.isBlank(location)) {
+            return false;
+        }
+
+        try {
+            URI uri = new URI(location);
+            String scheme = uri.getScheme();
+            
+            if (StringUtils.isBlank(scheme)) {
+                // No scheme means local or HDFS default
+                return supportedUriSchemes.contains("hdfs");
+            }
+            
+            return supportedUriSchemes.contains(scheme.toLowerCase());
+        } catch (Exception e) {
+            LOG.warn("Failed to parse location URI: {}", location);
+            return false;
+        }
+    }
+
+    private String getStorageServiceName(String location) {
+        if (StringUtils.isBlank(location)) {
+            return null;
+        }
+
+        try {
+            URI uri = new URI(location);
+            String scheme = uri.getScheme();
+
+            if (StringUtils.isBlank(scheme)) {
+                return hdfsServiceName;
+            }
+
+            scheme = scheme.toLowerCase();
+
+            if ("hdfs".equals(scheme)) {
+                return hdfsServiceName;
+            } else if ("o3fs".equals(scheme) || "ofs".equals(scheme)) {
+                return ozoneServiceName;
+            } else if ("s3a".equals(scheme) || "s3".equals(scheme) || "s3n".equals(scheme)) {
+                return s3ServiceName;
+            }
+
+            return hdfsServiceName;
+
+        } catch (Exception e) {
+            LOG.error("Failed to parse location URI: {}", location, e);
+            return null;
+        }
+    }
+
+    private Map<String, RangerPolicy.RangerPolicyResource> createHiveDatabaseResource(String databaseName) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+        ret.put(HIVE_RESOURCE_DATABASE, new RangerPolicy.RangerPolicyResource(databaseName));
+        return ret;
+    }
+
+    private Map<String, RangerPolicy.RangerPolicyResource> createHiveTableResource(String databaseName, String tableName) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+        ret.put(HIVE_RESOURCE_DATABASE, new RangerPolicy.RangerPolicyResource(databaseName));
+        ret.put(HIVE_RESOURCE_TABLE, new RangerPolicy.RangerPolicyResource(tableName));
+        return ret;
+    }
+
+    private Map<String, RangerPolicy.RangerPolicyResource> createStorageResource(String location) {
+        if (StringUtils.isBlank(location)) {
+            return null;
+        }
+
+        try {
+            URI uri = new URI(location);
+            String scheme = uri.getScheme();
+
+            if (StringUtils.isBlank(scheme)) {
+                scheme = "hdfs";
+            }
+
+            scheme = scheme.toLowerCase();
+
+            if ("hdfs".equals(scheme)) {
+                return createHdfsResource(uri);
+            } else if ("o3fs".equals(scheme) || "ofs".equals(scheme)) {
+                return createOzoneResource(uri, scheme);
+            } else if ("s3a".equals(scheme) || "s3".equals(scheme) || "s3n".equals(scheme)) {
+                return createS3Resource(uri);
+            }
+
+            return createHdfsResource(uri);
+
+        } catch (Exception e) {
+            LOG.error("Failed to create storage resource for location: {}", location, e);
+            return null;
+        }
+    }
+
+    private Map<String, RangerPolicy.RangerPolicyResource> createHdfsResource(URI uri) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+        String path = uri.getPath();
+        if (StringUtils.isNotBlank(path)) {
+            RangerPolicy.RangerPolicyResource pathResource = new RangerPolicy.RangerPolicyResource(path);
+            pathResource.setIsRecursive(true);
+            ret.put(HDFS_RESOURCE_PATH, pathResource);
+        }
+        return ret;
+    }
+
+    private Map<String, RangerPolicy.RangerPolicyResource> createOzoneResource(URI uri, String scheme) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+
+        if ("ofs".equals(scheme)) {
+            String path = uri.getPath();
+            if (StringUtils.isNotBlank(path)) {
+                String[] parts = path.split("/");
+                if (parts.length >= 2) {
+                    ret.put(OZONE_RESOURCE_VOLUME, new RangerPolicy.RangerPolicyResource(parts[1]));
+                    if (parts.length >= 3) {
+                        ret.put(OZONE_RESOURCE_BUCKET, new RangerPolicy.RangerPolicyResource(parts[2]));
+                        if (parts.length >= 4) {
+                            String key = String.join("/", java.util.Arrays.copyOfRange(parts, 3, parts.length));
+                            RangerPolicy.RangerPolicyResource keyResource = new RangerPolicy.RangerPolicyResource(key);
+                            keyResource.setIsRecursive(true);
+                            ret.put(OZONE_RESOURCE_KEY, keyResource);
+                        }
+                    }
+                }
+            }
+        } else {
+            String host = uri.getHost();
+            String path = uri.getPath();
+
+            if (StringUtils.isNotBlank(host)) {
+                String[] hostParts = host.split("\\.");
+                if (hostParts.length >= 2) {
+                    ret.put(OZONE_RESOURCE_BUCKET, new RangerPolicy.RangerPolicyResource(hostParts[0]));
+                    ret.put(OZONE_RESOURCE_VOLUME, new RangerPolicy.RangerPolicyResource(hostParts[1]));
+                }
+            }
+
+            if (StringUtils.isNotBlank(path) && !"/".equals(path)) {
+                String key = path.startsWith("/") ? path.substring(1) : path;
+                RangerPolicy.RangerPolicyResource keyResource = new RangerPolicy.RangerPolicyResource(key);
+                keyResource.setIsRecursive(true);
+                ret.put(OZONE_RESOURCE_KEY, keyResource);
+            }
+        }
+
+        return ret;
+    }
+
+    private Map<String, RangerPolicy.RangerPolicyResource> createS3Resource(URI uri) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+
+        String bucket = uri.getHost();
+        String path = uri.getPath();
+
+        if (StringUtils.isNotBlank(bucket)) {
+            ret.put(S3_RESOURCE_BUCKET, new RangerPolicy.RangerPolicyResource(bucket));
+        }
+
+        if (StringUtils.isNotBlank(path) && !"/".equals(path)) {
+            String s3Path = path.startsWith("/") ? path.substring(1) : path;
+            RangerPolicy.RangerPolicyResource pathResource = new RangerPolicy.RangerPolicyResource(s3Path);
+            pathResource.setIsRecursive(true);
+            ret.put(S3_RESOURCE_PATH, pathResource);
+        }
+
+        return ret;
+    }
+
+    private synchronized HMSClientWrapper getHMSClient() {
+        if (hmsClient != null && hmsClient.isConnected()) {
+            if (hmsClient.testConnection()) {
+                return hmsClient;
+            }
+            LOG.warn("HMS client connection lost, reconnecting...");
+            closeHMSClient();
+        }
+
+        try {
+            hmsClient = new HMSClientWrapper();
+            hmsClient.setSaslEnabled(hmsSaslEnabled);
+            hmsClient.setKerberosServerPrincipal(hmsKerberosPrincipal);
+            hmsClient.setSslEnabled(hmsSslEnabled);
+            hmsClient.setTruststorePath(hmsTruststorePath);
+            hmsClient.setTruststorePassword(hmsTruststorePassword);
+
+            boolean connected;
+            if (hmsSaslEnabled) {
+                ensureKerberosLogin();
+                connected = hmsClient.connectAsKerberosUser(hmsUri);
+            } else {
+                connected = hmsClient.connect(hmsUri);
+            }
+
+            if (connected) {
+                return hmsClient;
+            } else {
+                hmsClient = null;
+                return null;
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to create HMS client", e);
+            return null;
+        }
+    }
+
+    private synchronized void closeHMSClient() {
+        if (hmsClient != null) {
+            try {
+                hmsClient.close();
+            } catch (Exception e) {
+                LOG.debug("Error closing HMS client", e);
+            }
+            hmsClient = null;
+        }
+    }
+
+    /**
+     * Ensure a Kerberos TGT exists for the JVM before any SASL/GSSAPI handshake.
+     *
+     * Performs a one-shot {@code UserGroupInformation.loginUserFromKeytab} on first call,
+     * then on subsequent calls invokes {@code checkTGTAndReloginFromKeytab} so the ticket
+     * is renewed before expiry. Reflection is used to avoid a hard compile-time dependency
+     * on hadoop-common.
+     */
+    private void ensureKerberosLogin() {
+        if (StringUtils.isBlank(hmsClientPrincipal) || StringUtils.isBlank(hmsClientKeytab)) {
+            LOG.debug("RMS Kerberos client principal/keytab not configured; "
+                    + "relying on existing JVM login (ranger.rms.hms.kerberos.client.principal/keytab "
+                    + "or ranger.admin.kerberos.principal/keytab not set)");
+            return;
+        }
+
+        // UGI.loginUserFromKeytab() does NOT substitute _HOST in the principal —
+        // that is the job of SecurityUtil.getServerPrincipal(). If we hand a
+        // literal "service/_HOST@REALM" straight to loginUserFromKeytab, the
+        // JDK Krb5LoginModule fails with "Unable to obtain password from user"
+        // because the literal _HOST is not a real entry in the keytab.
+        String resolvedPrincipal = resolveHostInPrincipal(hmsClientPrincipal);
+
+        try {
+            Class<?> ugiClass = Class.forName("org.apache.hadoop.security.UserGroupInformation");
+
+            if (!kerberosLoginAttempted) {
+                java.lang.reflect.Method loginFromKeytab = ugiClass.getMethod(
+                        "loginUserFromKeytab", String.class, String.class);
+                LOG.info("Performing Kerberos login for RMS poller: principal={} (resolved from {}), keytab={}",
+                        resolvedPrincipal, hmsClientPrincipal, hmsClientKeytab);
+                loginFromKeytab.invoke(null, resolvedPrincipal, hmsClientKeytab);
+                kerberosLoginAttempted = true;
+
+                java.lang.reflect.Method getLoginUser = ugiClass.getMethod("getLoginUser");
+                Object loginUser = getLoginUser.invoke(null);
+                LOG.info("Kerberos login successful: loginUser={}", loginUser);
+            } else {
+                java.lang.reflect.Method getLoginUser = ugiClass.getMethod("getLoginUser");
+                Object loginUser = getLoginUser.invoke(null);
+                if (loginUser != null) {
+                    java.lang.reflect.Method relogin = ugiClass.getMethod("checkTGTAndReloginFromKeytab");
+                    relogin.invoke(loginUser);
+                }
+            }
+        } catch (ClassNotFoundException e) {
+            LOG.warn("Hadoop UserGroupInformation not found on classpath; cannot perform keytab login");
+        } catch (Exception e) {
+            LOG.error("Failed to login from keytab (principal={}, keytab={}): {}",
+                    resolvedPrincipal, hmsClientKeytab, e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Expand the literal {@code _HOST} token in a Kerberos principal to the
+     * local host's FQDN. Prefers Hadoop's {@code SecurityUtil.getServerPrincipal}
+     * when available (which uses DNS and matches Hadoop's own semantics); falls
+     * back to {@code InetAddress.getLocalHost().getCanonicalHostName()} otherwise.
+     */
+    private String resolveHostInPrincipal(String principal) {
+        if (StringUtils.isBlank(principal) || !principal.contains("_HOST")) {
+            return principal;
+        }
+        // Try Hadoop's SecurityUtil first for parity with other Hadoop components.
+        try {
+            Class<?> securityUtilClass = Class.forName("org.apache.hadoop.security.SecurityUtil");
+            java.lang.reflect.Method getServerPrincipal = securityUtilClass.getMethod(
+                    "getServerPrincipal", String.class, String.class);
+            Object resolved = getServerPrincipal.invoke(null, principal, (String) null);
+            if (resolved instanceof String && StringUtils.isNotBlank((String) resolved)
+                    && !((String) resolved).contains("_HOST")) {
+                return (String) resolved;
+            }
+        } catch (Exception e) {
+            LOG.debug("SecurityUtil.getServerPrincipal unavailable, falling back to local FQDN: {}", e.getMessage());
+        }
+        // Fallback: local canonical hostname.
+        try {
+            String fqdn = java.net.InetAddress.getLocalHost().getCanonicalHostName();
+            if (StringUtils.isNotBlank(fqdn)) {
+                return principal.replace("_HOST", fqdn);
+            }
+        } catch (Exception e) {
+            LOG.warn("Unable to resolve local canonical hostname for principal _HOST substitution: {}", e.getMessage());
+        }
+        return principal;
+    }
+
+    /**
+     * Trigger a full sync manually. Called via REST API.
+     */
+    public void triggerFullSync() {
+        LOG.info("Manual full sync triggered");
+        fullSyncCompleted.set(false);
+        // The next poll cycle will perform full sync
+    }
+
+    /**
+     * Get the last processed event ID.
+     */
+    public long getLastEventId() {
+        return lastEventId.get();
+    }
+
+    /**
+     * Check if RMS is enabled.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Check if full sync has been completed.
+     */
+    public boolean isFullSyncCompleted() {
+        return fullSyncCompleted.get();
+    }
+}

--- a/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
@@ -443,12 +443,18 @@ public class RangerRMSPollerService {
                             }
                         } catch (Exception e) {
                             stats.failed++;
-                            LOG.warn("Error processing table {}.{}: {}", dbName, tableName, e.getMessage());
+                            Throwable rootCause = e;
+                            while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+                                rootCause = rootCause.getCause();
+                            }
+                            LOG.warn("Error processing table {}.{}: [{}] {}",
+                                    dbName, tableName, rootCause.getClass().getName(), rootCause.getMessage(), e);
                         }
                     }
 
                 } catch (Exception e) {
-                    LOG.warn("Error processing database {}: {}", dbName, e.getMessage());
+                    LOG.warn("Error processing database {}: [{}] {}",
+                            dbName, e.getClass().getName(), e.getMessage(), e);
                 }
             }
 

--- a/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
@@ -116,6 +116,11 @@ public class RangerRMSPollerService {
     private static final String DEFAULT_S3_SERVICE_NAME = "s3";
     private static final String DEFAULT_SUPPORTED_URI_SCHEMES = "hdfs,o3fs,ofs,s3a";
     private static final long DEFAULT_POLLING_INTERVAL_MS = 30000;
+    // Lower bound on the HMS poll interval. A misconfigured 0 or negative
+    // value would make scheduleAtFixedRate throw IllegalArgumentException
+    // inside init(), failing Spring bean init and preventing Ranger Admin
+    // from starting. Anything below 5s is also unhealthy for HMS load.
+    private static final long MIN_POLLING_INTERVAL_MS = 5000;
 
     private static final String EVENT_CREATE_DATABASE = "CREATE_DATABASE";
     private static final String EVENT_DROP_DATABASE = "DROP_DATABASE";
@@ -167,6 +172,17 @@ public class RangerRMSPollerService {
     private AtomicBoolean isRunning = new AtomicBoolean(false);
     private AtomicBoolean fullSyncCompleted = new AtomicBoolean(false);
 
+    // Consecutive-empty-poll gate for the "range non-empty but response empty" case.
+    // A single empty response is indistinguishable from a real event gap vs. a
+    // transient HMS-VIP lag or metastore restart. Only after MIN_CONSECUTIVE_EMPTY_POLLS
+    // empties at the same watermark do we accept the "real gap" verdict and advance.
+    // Any non-empty response (progress) or a change to the watermark resets the counter.
+    // Only ever touched from the single-threaded poll executor thread, so plain
+    // fields are safe (no cross-thread visibility guarantees needed).
+    private static final int MIN_CONSECUTIVE_EMPTY_POLLS = 3;
+    private int consecutiveEmptyPolls = 0;
+    private long consecutiveEmptyPollsBaseEventId = -1L;
+
     @PostConstruct
     public void init() {
         LOG.info("==> RangerRMSPollerService.init()");
@@ -208,7 +224,12 @@ public class RangerRMSPollerService {
     private void loadConfiguration() {
         enabled = PropertiesUtil.getBooleanProperty(CONFIG_RMS_ENABLED, false);
         hmsUri = PropertiesUtil.getProperty(CONFIG_HMS_URI, "");
-        pollingIntervalMs = PropertiesUtil.getLongProperty(CONFIG_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL_MS);
+        long configuredPollingIntervalMs = PropertiesUtil.getLongProperty(CONFIG_POLLING_INTERVAL, DEFAULT_POLLING_INTERVAL_MS);
+        pollingIntervalMs = Math.max(MIN_POLLING_INTERVAL_MS, configuredPollingIntervalMs);
+        if (pollingIntervalMs != configuredPollingIntervalMs) {
+            LOG.warn("Configured {}={}ms is below the {}ms floor; clamped to {}ms",
+                    CONFIG_POLLING_INTERVAL, configuredPollingIntervalMs, MIN_POLLING_INTERVAL_MS, pollingIntervalMs);
+        }
         hiveServiceName = PropertiesUtil.getProperty(CONFIG_HIVE_SERVICE_NAME, DEFAULT_HIVE_SERVICE_NAME);
         hdfsServiceName = PropertiesUtil.getProperty(CONFIG_HDFS_SERVICE_NAME, DEFAULT_HDFS_SERVICE_NAME);
         ozoneServiceName = PropertiesUtil.getProperty(CONFIG_OZONE_SERVICE_NAME, DEFAULT_OZONE_SERVICE_NAME);
@@ -394,19 +415,47 @@ public class RangerRMSPollerService {
                         lastEventId.set(event.eventId);
                     }
                     persistState();
+                    // Progress observed — reset the empty-poll gate.
+                    consecutiveEmptyPolls = 0;
+                    consecutiveEmptyPollsBaseEventId = -1L;
                 } else {
                     // HMS reports a higher current event ID than we've processed
-                    // but returns no events for the requested range. This is
-                    // typically a real gap (events trimmed/expired between two
-                    // polls) rather than a transient error, but we cannot tell
-                    // for sure. Log loudly and skip ahead to currentEventId so
-                    // the poller does not get permanently stuck; subsequent
-                    // events will continue to be processed.
-                    LOG.warn("No notification events returned for range ({}, {}], "
-                            + "advancing watermark to {} (possible event gap on HMS)",
-                            lastEventId.get(), currentEventId, currentEventId);
-                    lastEventId.set(currentEventId);
-                    persistState();
+                    // but returned no events for the requested range. Two very
+                    // different possibilities produce the same signal:
+                    //   (a) real event gap — events between (lastEventId, currentEventId]
+                    //       were trimmed/expired between two polls; safe to advance.
+                    //   (b) transient empty — a lagging HMS secondary behind a
+                    //       load-balancer/VIP returned currentEventId but the
+                    //       matching event rows haven't replicated yet, or an HMS
+                    //       just restarted and the notification log is warming up.
+                    //       Advancing here permanently skips real events.
+                    //
+                    // Since we cannot tell (a) from (b) on a single poll, require
+                    // MIN_CONSECUTIVE_EMPTY_POLLS empties at the same watermark before
+                    // advancing. A subsequent non-empty response (progress) resets
+                    // the counter; a change to lastEventId from any other path also
+                    // resets it because the "base" no longer matches.
+                    long base = lastEventId.get();
+                    if (consecutiveEmptyPollsBaseEventId != base) {
+                        consecutiveEmptyPollsBaseEventId = base;
+                        consecutiveEmptyPolls = 1;
+                    } else {
+                        consecutiveEmptyPolls++;
+                    }
+
+                    if (consecutiveEmptyPolls >= MIN_CONSECUTIVE_EMPTY_POLLS) {
+                        LOG.warn("No notification events for range ({}, {}] across {} consecutive polls, "
+                                + "advancing watermark to {} (accepting event gap on HMS)",
+                                base, currentEventId, consecutiveEmptyPolls, currentEventId);
+                        lastEventId.set(currentEventId);
+                        persistState();
+                        consecutiveEmptyPolls = 0;
+                        consecutiveEmptyPollsBaseEventId = -1L;
+                    } else {
+                        LOG.info("No notification events for range ({}, {}] "
+                                + "(empty poll {}/{} at same watermark; waiting before advancing)",
+                                base, currentEventId, consecutiveEmptyPolls, MIN_CONSECUTIVE_EMPTY_POLLS);
+                    }
                 }
             } catch (Exception e) {
                 // On fetch / processing error keep the watermark unchanged so
@@ -418,8 +467,14 @@ public class RangerRMSPollerService {
             }
             LOG.debug("<== pollHMS() processed events up to eventId={}", lastEventId.get());
 
-        } catch (Exception e) {
-            LOG.error("Error polling HMS for notifications", e);
+        } catch (Throwable t) {
+            // Catching Throwable (not just Exception) because scheduleAtFixedRate
+            // suppresses all future runs if the task escapes with an uncaught
+            // Throwable — an Error from the Thrift/Hive reflection init path
+            // (NoClassDefFoundError, ExceptionInInitializerError) or a sync-time
+            // OutOfMemoryError would otherwise silently kill the poller until
+            // Admin restart, with no further log lines.
+            LOG.error("Error polling HMS for notifications", t);
             closeHMSClient();
         } finally {
             isRunning.set(false);

--- a/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
+++ b/security-admin/src/main/java/org/apache/ranger/rms/RangerRMSPollerService.java
@@ -91,6 +91,25 @@ public class RangerRMSPollerService {
     private static final String CONFIG_RANGER_ADMIN_PRINCIPAL = "ranger.admin.kerberos.principal";
     private static final String CONFIG_RANGER_ADMIN_KEYTAB = "ranger.admin.kerberos.keytab";
 
+    // Initial full-sync scale controls (added to support 1M+ table clusters).
+    // Serial + per-table Thrift RPCs cannot finish in a reasonable time at
+    // that scale; these knobs turn the outer database loop into a bounded
+    // thread pool with per-worker HMS clients, and turn the inner per-table
+    // fetch into a single batched Thrift call.
+    private static final String CONFIG_FULLSYNC_PARALLELISM = "ranger.rms.fullsync.parallelism";
+    private static final String CONFIG_FULLSYNC_BATCH_SIZE = "ranger.rms.fullsync.batch.size";
+    private static final String CONFIG_FULLSYNC_INCLUDED_DB_REGEX = "ranger.rms.fullsync.included.databases.regex";
+    private static final String CONFIG_FULLSYNC_EXCLUDED_DB_REGEX = "ranger.rms.fullsync.excluded.databases.regex";
+
+    private static final int DEFAULT_FULLSYNC_PARALLELISM = 8;
+    private static final int DEFAULT_FULLSYNC_BATCH_SIZE = 200;
+    // Skip the two schema-owned databases HMS ships with by default.
+    private static final String DEFAULT_FULLSYNC_EXCLUDED_DB_REGEX = "(?i)^(sys|information_schema)$";
+    // Absolute upper bound on parallelism: too many concurrent connections
+    // are a DoS vector on HMS's Thrift server. If you're running with a
+    // sharded/replicated HMS behind a VIP you can raise this at build time.
+    private static final int MAX_FULLSYNC_PARALLELISM = 32;
+
     private static final String DEFAULT_HIVE_SERVICE_NAME = "hive";
     private static final String DEFAULT_HDFS_SERVICE_NAME = "hdfs";
     private static final String DEFAULT_OZONE_SERVICE_NAME = "ozone";
@@ -137,6 +156,11 @@ public class RangerRMSPollerService {
     private String hmsTruststorePassword;
     private boolean kerberosLoginAttempted = false;
 
+    private int fullSyncParallelism;
+    private int fullSyncBatchSize;
+    private java.util.regex.Pattern fullSyncIncludedDbPattern;
+    private java.util.regex.Pattern fullSyncExcludedDbPattern;
+
     private ScheduledExecutorService scheduler;
     private HMSClientWrapper hmsClient;
     private AtomicLong lastEventId = new AtomicLong(-1);
@@ -166,6 +190,10 @@ public class RangerRMSPollerService {
         LOG.info("  hmsClientKeytab:      {}", hmsClientKeytab);
         LOG.info("  hmsSslEnabled: {}", hmsSslEnabled);
         LOG.info("  hmsTruststorePath: {}", hmsTruststorePath);
+        LOG.info("  fullSyncParallelism: {}", fullSyncParallelism);
+        LOG.info("  fullSyncBatchSize: {}", fullSyncBatchSize);
+        LOG.info("  fullSyncIncludedDbRegex: {}", fullSyncIncludedDbPattern == null ? "(all)" : fullSyncIncludedDbPattern.pattern());
+        LOG.info("  fullSyncExcludedDbRegex: {}", fullSyncExcludedDbPattern == null ? "(none)" : fullSyncExcludedDbPattern.pattern());
 
         if (enabled) {
             restoreState();
@@ -211,6 +239,15 @@ public class RangerRMSPollerService {
         for (String scheme : schemes.split(",")) {
             supportedUriSchemes.add(scheme.trim().toLowerCase());
         }
+
+        int rawParallelism = PropertiesUtil.getIntProperty(CONFIG_FULLSYNC_PARALLELISM, DEFAULT_FULLSYNC_PARALLELISM);
+        fullSyncParallelism = Math.max(1, Math.min(MAX_FULLSYNC_PARALLELISM, rawParallelism));
+        fullSyncBatchSize = Math.max(1, PropertiesUtil.getIntProperty(CONFIG_FULLSYNC_BATCH_SIZE, DEFAULT_FULLSYNC_BATCH_SIZE));
+
+        String includedRegex = PropertiesUtil.getProperty(CONFIG_FULLSYNC_INCLUDED_DB_REGEX, "");
+        fullSyncIncludedDbPattern = StringUtils.isBlank(includedRegex) ? null : java.util.regex.Pattern.compile(includedRegex);
+        String excludedRegex = PropertiesUtil.getProperty(CONFIG_FULLSYNC_EXCLUDED_DB_REGEX, DEFAULT_FULLSYNC_EXCLUDED_DB_REGEX);
+        fullSyncExcludedDbPattern = StringUtils.isBlank(excludedRegex) ? null : java.util.regex.Pattern.compile(excludedRegex);
     }
 
     private void restoreState() {
@@ -405,66 +442,267 @@ public class RangerRMSPollerService {
         }
     }
 
-    private FullSyncStats performFullSync(HMSClientWrapper client) throws Exception {
-        LOG.info("==> performFullSync()");
+    /**
+     * Full-sync the HMS catalog into RMS.
+     *
+     * At the scale we target on this branch (up to a few million tables) a
+     * serial per-table walk is not viable — a naive implementation takes
+     * many hours and holds a hot write-lock on
+     * {@code x_rms_mapping_provider.last_known_version} for every row.
+     *
+     * <p>Three coordinated optimizations run here:
+     * <ol>
+     *   <li><b>Bulk mode:</b> {@link RMSMgr#beginBulkFullSync()} reserves the
+     *       next {@code mapping_version} up-front, and every
+     *       {@code createOrUpdateMapping} write during the sync uses that
+     *       reserved version without bumping the provider row. The single
+     *       commit-bump happens in {@link RMSMgr#endBulkFullSync(boolean)}
+     *       at the end. Plugins polling mid-sync see the previous version and
+     *       receive "no change" — they never observe intermediate state.</li>
+     *   <li><b>Parallel database workers:</b> the outer database loop runs
+     *       across N worker threads (see {@code ranger.rms.fullsync.parallelism}).
+     *       Each worker owns its own {@link HMSClientWrapper} because the
+     *       wrapper wraps a single non-thread-safe Thrift transport. Databases
+     *       are independent units of work in HMS, so this fans out cleanly.</li>
+     *   <li><b>Batched table fetch:</b> instead of one {@code get_table} RPC
+     *       per table, each worker groups the table list of a database into
+     *       chunks of {@code ranger.rms.fullsync.batch.size} and calls the
+     *       bulk {@code get_table_objects_by_name_req} Thrift API. Cuts
+     *       round-trips ~100-200×.</li>
+     * </ol>
+     */
+    private FullSyncStats performFullSync(HMSClientWrapper primaryClient) throws Exception {
+        LOG.info("==> performFullSync(parallelism={}, batchSize={})", fullSyncParallelism, fullSyncBatchSize);
 
         FullSyncStats stats = new FullSyncStats();
 
+        List<String> allDatabases;
         try {
-            List<String> databases = client.getAllDatabases();
-            LOG.info("Found {} databases in HMS", databases.size());
+            allDatabases = primaryClient.getAllDatabases();
+        } catch (Exception e) {
+            LOG.error("Error listing databases from HMS", e);
+            throw e;
+        }
+        LOG.info("Found {} databases in HMS", allDatabases.size());
 
-            for (String dbName : databases) {
-                try {
-                    if ("sys".equalsIgnoreCase(dbName) || "information_schema".equalsIgnoreCase(dbName)) {
-                        continue;
-                    }
+        List<String> databases = filterDatabases(allDatabases);
+        LOG.info("After include/exclude filtering: {} databases eligible for sync", databases.size());
 
-                    DatabaseInfo db = client.getDatabase(dbName);
-                    if (db != null) {
-                        String dbLocation = db.locationUri;
-                        if (StringUtils.isNotBlank(dbLocation) && isSupportedLocation(dbLocation)) {
-                            stats.attempted++;
-                            if (!processCreateDatabase(dbName, dbLocation)) {
-                                stats.failed++;
-                            }
+        if (databases.isEmpty()) {
+            LOG.info("<== performFullSync() attempted=0, failed=0 (no databases to sync)");
+            return stats;
+        }
+
+        rmsMgr.beginBulkFullSync();
+        boolean bulkSuccess = false;
+        java.util.concurrent.ExecutorService executor = null;
+        List<HMSClientWrapper> workerClients = new java.util.ArrayList<>();
+        java.util.concurrent.atomic.AtomicInteger attempted = new java.util.concurrent.atomic.AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicInteger failed = new java.util.concurrent.atomic.AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicInteger dbCounter = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        try {
+            // We want the primary client to remain usable for post-sync work
+            // (e.g. get_current_notificationEventId). If parallelism == 1 the
+            // primary client is our only worker; if > 1 we spin up fresh
+            // wrappers so we don't share a non-thread-safe Thrift connection.
+            int workers = fullSyncParallelism;
+            executor = java.util.concurrent.Executors.newFixedThreadPool(workers,
+                    new java.util.concurrent.ThreadFactory() {
+                        private final java.util.concurrent.atomic.AtomicInteger seq = new java.util.concurrent.atomic.AtomicInteger();
+                        @Override public Thread newThread(Runnable r) {
+                            Thread t = new Thread(r, "RMS-FullSync-Worker-" + seq.incrementAndGet());
+                            t.setDaemon(true);
+                            return t;
                         }
-                    }
+                    });
 
-                    List<String> tables = client.getAllTables(dbName);
-                    LOG.info("Database {}: found {} tables", dbName, tables.size());
+            for (int i = 0; i < workers; i++) {
+                HMSClientWrapper client = (i == 0) ? primaryClient : createHMSClient();
+                if (client == null) {
+                    LOG.warn("Could not create HMS client for worker #{}, reducing parallelism", i);
+                    continue;
+                }
+                workerClients.add(client);
+            }
 
-                    for (String tableName : tables) {
+            if (workerClients.isEmpty()) {
+                throw new IllegalStateException("No HMS clients available for full sync");
+            }
+
+            int effectiveWorkers = workerClients.size();
+            LOG.info("Full sync starting with {} worker(s), {} database(s), batch size {}",
+                    effectiveWorkers, databases.size(), fullSyncBatchSize);
+
+            // Round-robin each database to a fixed worker so we never share
+            // a wrapper across threads. This is simpler than a work-stealing
+            // queue over a client pool and adequate: within a worker the
+            // per-database cost is dominated by table count, and Hive
+            // clusters have a long-tail distribution across databases.
+            List<java.util.concurrent.Future<?>> futures = new java.util.ArrayList<>();
+            for (int i = 0; i < effectiveWorkers; i++) {
+                final int workerIdx = i;
+                final HMSClientWrapper client = workerClients.get(i);
+                futures.add(executor.submit(() -> {
+                    for (int dbIdx = workerIdx; dbIdx < databases.size(); dbIdx += effectiveWorkers) {
+                        String dbName = databases.get(dbIdx);
+                        int done = dbCounter.incrementAndGet();
                         try {
-                            TableInfo table = client.getTable(dbName, tableName);
-                            stats.attempted++;
-                            if (!processTable(table)) {
-                                stats.failed++;
-                            }
+                            processDatabaseFully(client, dbName, attempted, failed);
                         } catch (Exception e) {
-                            stats.failed++;
-                            Throwable rootCause = e;
-                            while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
-                                rootCause = rootCause.getCause();
-                            }
-                            LOG.warn("Error processing table {}.{}: [{}] {}",
-                                    dbName, tableName, rootCause.getClass().getName(), rootCause.getMessage(), e);
+                            Throwable rootCause = unwrap(e);
+                            LOG.warn("Error processing database {}: [{}] {}",
+                                    dbName, rootCause.getClass().getName(), rootCause.getMessage(), e);
+                        }
+                        if (done % 100 == 0 || done == databases.size()) {
+                            LOG.info("Full sync progress: {}/{} databases processed, attempted={}, failed={}",
+                                    done, databases.size(), attempted.get(), failed.get());
                         }
                     }
+                }));
+            }
 
+            for (java.util.concurrent.Future<?> f : futures) {
+                try {
+                    f.get();
                 } catch (Exception e) {
-                    LOG.warn("Error processing database {}: [{}] {}",
-                            dbName, e.getClass().getName(), e.getMessage(), e);
+                    LOG.warn("Full sync worker terminated with error: {}", e.getMessage(), e);
                 }
             }
 
-        } catch (Exception e) {
-            LOG.error("Error during full sync", e);
-            throw e;
+            stats.attempted = attempted.get();
+            stats.failed = failed.get();
+
+            // Only commit the reserved version if at least one write succeeded.
+            // isFullyFailed() (checked by the caller) additionally guards the
+            // fullSyncCompleted flag; consistent semantics between the two.
+            bulkSuccess = stats.attempted > 0 && !stats.isFullyFailed();
+
+        } finally {
+            rmsMgr.endBulkFullSync(bulkSuccess);
+            if (executor != null) {
+                executor.shutdownNow();
+            }
+            // Close every extra worker client we opened. The primary client
+            // stays open — the poll loop needs it for the notification cursor.
+            for (int i = 1; i < workerClients.size(); i++) {
+                try {
+                    workerClients.get(i).close();
+                } catch (Exception ignored) { /* best-effort cleanup */ }
+            }
         }
 
-        LOG.info("<== performFullSync() attempted={}, failed={}", stats.attempted, stats.failed);
+        LOG.info("<== performFullSync() attempted={}, failed={}, bulkCommitted={}",
+                stats.attempted, stats.failed, bulkSuccess);
         return stats;
+    }
+
+    /**
+     * Process a single database's worth of work using the given (worker-owned)
+     * HMS client: fetch DB metadata, walk tables in batches, and hand each
+     * batch to {@link #processTable} via {@link RMSMgr#createOrUpdateMapping}.
+     * Failures on individual tables are logged but never propagate — one bad
+     * table shouldn't fail the whole sync.
+     */
+    private void processDatabaseFully(HMSClientWrapper client,
+                                       String dbName,
+                                       java.util.concurrent.atomic.AtomicInteger attempted,
+                                       java.util.concurrent.atomic.AtomicInteger failed) {
+        try {
+            DatabaseInfo db = client.getDatabase(dbName);
+            if (db != null) {
+                String dbLocation = db.locationUri;
+                if (StringUtils.isNotBlank(dbLocation) && isSupportedLocation(dbLocation)) {
+                    attempted.incrementAndGet();
+                    if (!processCreateDatabase(dbName, dbLocation)) {
+                        failed.incrementAndGet();
+                    }
+                }
+            }
+
+            List<String> tables = client.getAllTables(dbName);
+            if (tables == null || tables.isEmpty()) {
+                return;
+            }
+            LOG.info("Database {}: found {} tables", dbName, tables.size());
+
+            for (int start = 0; start < tables.size(); start += fullSyncBatchSize) {
+                int end = Math.min(start + fullSyncBatchSize, tables.size());
+                List<String> batch = tables.subList(start, end);
+
+                List<TableInfo> fetched;
+                try {
+                    fetched = client.getTables(dbName, batch);
+                } catch (Exception e) {
+                    // Bulk fetch failed for the whole batch. Charge each
+                    // requested table to `failed` so isFullyFailed() sees
+                    // the true error rate.
+                    failed.addAndGet(batch.size());
+                    attempted.addAndGet(batch.size());
+                    Throwable rootCause = unwrap(e);
+                    LOG.warn("Error batch-fetching tables from {} (batch {}..{}): [{}] {}",
+                            dbName, start, end, rootCause.getClass().getName(), rootCause.getMessage(), e);
+                    continue;
+                }
+
+                for (TableInfo table : fetched) {
+                    attempted.incrementAndGet();
+                    try {
+                        if (!processTable(table)) {
+                            failed.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        failed.incrementAndGet();
+                        Throwable rootCause = unwrap(e);
+                        LOG.warn("Error processing table {}.{}: [{}] {}",
+                                dbName, table != null ? table.tableName : "?",
+                                rootCause.getClass().getName(), rootCause.getMessage(), e);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Throwable rootCause = unwrap(e);
+            LOG.warn("Error processing database {}: [{}] {}",
+                    dbName, rootCause.getClass().getName(), rootCause.getMessage(), e);
+        }
+    }
+
+    /**
+     * Walk an exception's cause chain to its terminal cause. Used to surface
+     * the real HMS-side error (e.g.Â {@code UnsupportedFileSystemException:
+     * No FileSystem for scheme "ofs"}) on the WARN one-liner instead of the
+     * outer reflection wrapper (usually {@code InvocationTargetException}
+     * with a {@code null} message that hides the actual problem).
+     *
+     * <p>Cycle-guarded: some exception chains reference themselves as their
+     * own cause, so we bail if we see the same throwable twice.
+     */
+    private static Throwable unwrap(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) {
+            cur = cur.getCause();
+        }
+        return cur;
+    }
+
+    /**
+     * Apply include/exclude regex filters to the raw HMS database list.
+     * Returns a new list preserving input order (workers stripe over it).
+     */
+    private List<String> filterDatabases(List<String> allDatabases) {
+        List<String> result = new java.util.ArrayList<>(allDatabases.size());
+        for (String dbName : allDatabases) {
+            if (fullSyncIncludedDbPattern != null && !fullSyncIncludedDbPattern.matcher(dbName).matches()) {
+                LOG.debug("Skipping {}: does not match include regex", dbName);
+                continue;
+            }
+            if (fullSyncExcludedDbPattern != null && fullSyncExcludedDbPattern.matcher(dbName).matches()) {
+                LOG.debug("Skipping {}: matches exclude regex", dbName);
+                continue;
+            }
+            result.add(dbName);
+        }
+        return result;
     }
 
     private void processNotificationEvent(HMSClientWrapper client, NotificationEventInfo event) {
@@ -874,29 +1112,34 @@ public class RangerRMSPollerService {
             LOG.warn("HMS client connection lost, reconnecting...");
             closeHMSClient();
         }
+        hmsClient = createHMSClient();
+        return hmsClient;
+    }
 
+    /**
+     * Build a fresh, connected HMS client instance without touching the
+     * singleton {@link #hmsClient}. Used by parallel full-sync workers, each
+     * of which owns its own client because {@code HMSClientWrapper} wraps a
+     * single Thrift connection and is NOT thread-safe. Returns {@code null}
+     * if the connection or Kerberos handshake fails.
+     */
+    private HMSClientWrapper createHMSClient() {
         try {
-            hmsClient = new HMSClientWrapper();
-            hmsClient.setSaslEnabled(hmsSaslEnabled);
-            hmsClient.setKerberosServerPrincipal(hmsKerberosPrincipal);
-            hmsClient.setSslEnabled(hmsSslEnabled);
-            hmsClient.setTruststorePath(hmsTruststorePath);
-            hmsClient.setTruststorePassword(hmsTruststorePassword);
+            HMSClientWrapper client = new HMSClientWrapper();
+            client.setSaslEnabled(hmsSaslEnabled);
+            client.setKerberosServerPrincipal(hmsKerberosPrincipal);
+            client.setSslEnabled(hmsSslEnabled);
+            client.setTruststorePath(hmsTruststorePath);
+            client.setTruststorePassword(hmsTruststorePassword);
 
             boolean connected;
             if (hmsSaslEnabled) {
                 ensureKerberosLogin();
-                connected = hmsClient.connectAsKerberosUser(hmsUri);
+                connected = client.connectAsKerberosUser(hmsUri);
             } else {
-                connected = hmsClient.connect(hmsUri);
+                connected = client.connect(hmsUri);
             }
-
-            if (connected) {
-                return hmsClient;
-            } else {
-                hmsClient = null;
-                return null;
-            }
+            return connected ? client : null;
         } catch (Exception e) {
             LOG.error("Failed to create HMS client", e);
             return null;

--- a/security-admin/src/main/java/org/apache/ranger/service/RangerHMSNotificationHandler.java
+++ b/security-admin/src/main/java/org/apache/ranger/service/RangerHMSNotificationHandler.java
@@ -1,0 +1,501 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.ranger.service;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.ranger.biz.RMSMgr;
+import org.apache.ranger.plugin.model.RangerPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * RangerHMSNotificationHandler handles HMS (Hive Metastore) notifications
+ * and updates RMS mappings accordingly.
+ *
+ * This service can be configured to:
+ * 1. Poll HMS for notification events (if HMS notification API is available)
+ * 2. Receive push notifications from HMS (via REST callback)
+ * 3. Accept manual mapping updates via REST API
+ *
+ * Configuration properties:
+ * - ranger.rms.hms.enabled: Enable/disable HMS notification processing
+ * - ranger.rms.hms.polling.interval.ms: Polling interval in milliseconds
+ * - ranger.rms.hive.service.name: Name of the Hive service in Ranger
+ * - ranger.rms.hdfs.service.name: Name of the HDFS service in Ranger
+ * - ranger.rms.ozone.service.name: Name of the Ozone service in Ranger
+ * - ranger.rms.s3.service.name: Name of the S3 service in Ranger
+ * - ranger.rms.supported.uri.schemes: Comma-separated list of supported URI schemes
+ */
+@Service
+public class RangerHMSNotificationHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(RangerHMSNotificationHandler.class);
+
+    private static final String DEFAULT_HIVE_SERVICE_NAME = "hive";
+    private static final String DEFAULT_HDFS_SERVICE_NAME = "hdfs";
+    private static final String DEFAULT_OZONE_SERVICE_NAME = "ozone";
+    private static final String DEFAULT_S3_SERVICE_NAME = "s3";
+    private static final String DEFAULT_SUPPORTED_URI_SCHEMES = "hdfs,o3fs,ofs,s3a";
+
+    private static final String HIVE_RESOURCE_DATABASE = "database";
+    private static final String HIVE_RESOURCE_TABLE = "table";
+    private static final String HIVE_RESOURCE_COLUMN = "column";
+
+    private static final String HDFS_RESOURCE_PATH = "path";
+    private static final String OZONE_RESOURCE_VOLUME = "volume";
+    private static final String OZONE_RESOURCE_BUCKET = "bucket";
+    private static final String OZONE_RESOURCE_KEY = "key";
+    private static final String S3_RESOURCE_BUCKET = "bucket";
+    private static final String S3_RESOURCE_PATH = "path";
+
+    @Autowired
+    private RMSMgr rmsMgr;
+
+    @Value("${ranger.rms.hms.enabled:false}")
+    private boolean hmsEnabled;
+
+    @Value("${ranger.rms.hms.polling.interval.ms:30000}")
+    private long pollingIntervalMs;
+
+    @Value("${ranger.rms.hive.service.name:" + DEFAULT_HIVE_SERVICE_NAME + "}")
+    private String hiveServiceName;
+
+    @Value("${ranger.rms.hdfs.service.name:" + DEFAULT_HDFS_SERVICE_NAME + "}")
+    private String hdfsServiceName;
+
+    @Value("${ranger.rms.ozone.service.name:" + DEFAULT_OZONE_SERVICE_NAME + "}")
+    private String ozoneServiceName;
+
+    @Value("${ranger.rms.s3.service.name:" + DEFAULT_S3_SERVICE_NAME + "}")
+    private String s3ServiceName;
+
+    @Value("${ranger.rms.supported.uri.schemes:" + DEFAULT_SUPPORTED_URI_SCHEMES + "}")
+    private String supportedUriSchemes;
+
+    @Value("${ranger.rms.map.managed.tables:false}")
+    private boolean mapManagedTables;
+
+    private ScheduledExecutorService scheduler;
+
+    @PostConstruct
+    public void init() {
+        LOG.info("==> RangerHMSNotificationHandler.init()");
+        LOG.info("RMS HMS notification handler configuration:");
+        LOG.info("  hmsEnabled: {}", hmsEnabled);
+        LOG.info("  pollingIntervalMs: {}", pollingIntervalMs);
+        LOG.info("  hiveServiceName: {}", hiveServiceName);
+        LOG.info("  hdfsServiceName: {}", hdfsServiceName);
+        LOG.info("  ozoneServiceName: {}", ozoneServiceName);
+        LOG.info("  s3ServiceName: {}", s3ServiceName);
+        LOG.info("  supportedUriSchemes: {}", supportedUriSchemes);
+        LOG.info("  mapManagedTables: {}", mapManagedTables);
+
+        if (hmsEnabled) {
+            startPolling();
+        }
+
+        LOG.info("<== RangerHMSNotificationHandler.init()");
+    }
+
+    @PreDestroy
+    public void cleanup() {
+        LOG.info("==> RangerHMSNotificationHandler.cleanup()");
+        if (scheduler != null) {
+            scheduler.shutdown();
+            try {
+                if (!scheduler.awaitTermination(30, TimeUnit.SECONDS)) {
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+        LOG.info("<== RangerHMSNotificationHandler.cleanup()");
+    }
+
+    private void startPolling() {
+        LOG.info("Starting HMS notification polling with interval: {}ms", pollingIntervalMs);
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "RMS-HMS-Notification-Poller");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.scheduleAtFixedRate(this::pollHMSNotifications, 
+            pollingIntervalMs, pollingIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void pollHMSNotifications() {
+        LOG.debug("==> pollHMSNotifications()");
+        LOG.debug("<== pollHMSNotifications()");
+    }
+
+    /**
+     * Process a database creation event.
+     */
+    public void handleDatabaseCreate(String databaseName, String location) {
+        LOG.info("==> handleDatabaseCreate(database={}, location={})", databaseName, location);
+
+        if (StringUtils.isBlank(databaseName) || StringUtils.isBlank(location)) {
+            LOG.warn("Invalid database create event: database={}, location={}", databaseName, location);
+            return;
+        }
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveDatabaseResource(databaseName);
+            String llServiceName = getStorageServiceName(location);
+            Map<String, RangerPolicy.RangerPolicyResource> storageResource = createStorageResource(location);
+
+            if (llServiceName != null && storageResource != null) {
+                rmsMgr.createOrUpdateMapping(hiveServiceName, hiveResource, llServiceName, storageResource, location);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to handle database create event: database={}", databaseName, e);
+        }
+
+        LOG.info("<== handleDatabaseCreate(database={})", databaseName);
+    }
+
+    /**
+     * Process a database drop event.
+     */
+    public void handleDatabaseDrop(String databaseName, String location) {
+        LOG.info("==> handleDatabaseDrop(database={}, location={})", databaseName, location);
+
+        if (StringUtils.isBlank(databaseName)) {
+            return;
+        }
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveDatabaseResource(databaseName);
+            String llServiceName = getStorageServiceName(location);
+            Map<String, RangerPolicy.RangerPolicyResource> storageResource = createStorageResource(location);
+
+            if (llServiceName != null && storageResource != null) {
+                rmsMgr.deleteMapping(hiveServiceName, hiveResource, llServiceName, storageResource);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to handle database drop event: database={}", databaseName, e);
+        }
+
+        LOG.info("<== handleDatabaseDrop(database={})", databaseName);
+    }
+
+    /**
+     * Process a table creation event.
+     */
+    public void handleTableCreate(String databaseName, String tableName, String location, boolean isManaged) {
+        LOG.info("==> handleTableCreate(database={}, table={}, location={}, isManaged={})",
+                 databaseName, tableName, location, isManaged);
+
+        if (StringUtils.isBlank(databaseName) || StringUtils.isBlank(tableName) || StringUtils.isBlank(location)) {
+            LOG.warn("Invalid table create event");
+            return;
+        }
+
+        if (isManaged && !mapManagedTables) {
+            LOG.debug("Skipping managed table: {}.{}", databaseName, tableName);
+            return;
+        }
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveTableResource(databaseName, tableName);
+            String llServiceName = getStorageServiceName(location);
+            Map<String, RangerPolicy.RangerPolicyResource> storageResource = createStorageResource(location);
+
+            if (llServiceName != null && storageResource != null) {
+                rmsMgr.createOrUpdateMapping(hiveServiceName, hiveResource, llServiceName, storageResource, location);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to handle table create event: {}.{}", databaseName, tableName, e);
+        }
+
+        LOG.info("<== handleTableCreate(database={}, table={})", databaseName, tableName);
+    }
+
+    /**
+     * Process a table drop event.
+     */
+    public void handleTableDrop(String databaseName, String tableName, String location) {
+        LOG.info("==> handleTableDrop(database={}, table={}, location={})", databaseName, tableName, location);
+
+        if (StringUtils.isBlank(databaseName) || StringUtils.isBlank(tableName)) {
+            return;
+        }
+
+        try {
+            Map<String, RangerPolicy.RangerPolicyResource> hiveResource = createHiveTableResource(databaseName, tableName);
+            String llServiceName = getStorageServiceName(location);
+            Map<String, RangerPolicy.RangerPolicyResource> storageResource = createStorageResource(location);
+
+            if (llServiceName != null && storageResource != null) {
+                rmsMgr.deleteMapping(hiveServiceName, hiveResource, llServiceName, storageResource);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to handle table drop event: {}.{}", databaseName, tableName, e);
+        }
+
+        LOG.info("<== handleTableDrop(database={}, table={})", databaseName, tableName);
+    }
+
+    /**
+     * Process a table alter event (location change).
+     */
+    public void handleTableAlter(String databaseName, String tableName, String oldLocation, String newLocation) {
+        LOG.info("==> handleTableAlter(database={}, table={}, oldLocation={}, newLocation={})",
+                 databaseName, tableName, oldLocation, newLocation);
+
+        if (StringUtils.isNotBlank(oldLocation)) {
+            handleTableDrop(databaseName, tableName, oldLocation);
+        }
+
+        if (StringUtils.isNotBlank(newLocation)) {
+            handleTableCreate(databaseName, tableName, newLocation, false);
+        }
+
+        LOG.info("<== handleTableAlter(database={}, table={})", databaseName, tableName);
+    }
+
+    /**
+     * Create Hive database resource elements.
+     */
+    private Map<String, RangerPolicy.RangerPolicyResource> createHiveDatabaseResource(String databaseName) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+        ret.put(HIVE_RESOURCE_DATABASE, new RangerPolicy.RangerPolicyResource(databaseName));
+        return ret;
+    }
+
+    /**
+     * Create Hive table resource elements.
+     */
+    private Map<String, RangerPolicy.RangerPolicyResource> createHiveTableResource(String databaseName, String tableName) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+        ret.put(HIVE_RESOURCE_DATABASE, new RangerPolicy.RangerPolicyResource(databaseName));
+        ret.put(HIVE_RESOURCE_TABLE, new RangerPolicy.RangerPolicyResource(tableName));
+        return ret;
+    }
+
+    /**
+     * Get the storage service name based on the location URI scheme.
+     */
+    private String getStorageServiceName(String location) {
+        if (StringUtils.isBlank(location)) {
+            return null;
+        }
+
+        try {
+            URI uri = new URI(location);
+            String scheme = uri.getScheme();
+
+            if (StringUtils.isBlank(scheme)) {
+                return hdfsServiceName;
+            }
+
+            scheme = scheme.toLowerCase();
+
+            if (!isSupportedScheme(scheme)) {
+                LOG.warn("Unsupported URI scheme: {}", scheme);
+                return null;
+            }
+
+            if ("hdfs".equals(scheme)) {
+                return hdfsServiceName;
+            } else if ("o3fs".equals(scheme) || "ofs".equals(scheme)) {
+                return ozoneServiceName;
+            } else if ("s3a".equals(scheme) || "s3".equals(scheme) || "s3n".equals(scheme)) {
+                return s3ServiceName;
+            }
+
+            return hdfsServiceName;
+
+        } catch (Exception e) {
+            LOG.error("Failed to parse location URI: {}", location, e);
+            return null;
+        }
+    }
+
+    /**
+     * Check if a URI scheme is supported.
+     */
+    private boolean isSupportedScheme(String scheme) {
+        if (StringUtils.isBlank(supportedUriSchemes)) {
+            return true;
+        }
+
+        for (String supported : supportedUriSchemes.split(",")) {
+            if (supported.trim().equalsIgnoreCase(scheme)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Create storage resource elements based on the location.
+     */
+    private Map<String, RangerPolicy.RangerPolicyResource> createStorageResource(String location) {
+        if (StringUtils.isBlank(location)) {
+            return null;
+        }
+
+        try {
+            URI uri = new URI(location);
+            String scheme = uri.getScheme();
+
+            if (StringUtils.isBlank(scheme)) {
+                scheme = "hdfs";
+            }
+
+            scheme = scheme.toLowerCase();
+
+            if ("hdfs".equals(scheme)) {
+                return createHdfsResource(uri);
+            } else if ("o3fs".equals(scheme) || "ofs".equals(scheme)) {
+                return createOzoneResource(uri, scheme);
+            } else if ("s3a".equals(scheme) || "s3".equals(scheme) || "s3n".equals(scheme)) {
+                return createS3Resource(uri);
+            }
+
+            return createHdfsResource(uri);
+
+        } catch (Exception e) {
+            LOG.error("Failed to create storage resource for location: {}", location, e);
+            return null;
+        }
+    }
+
+    /**
+     * Create HDFS resource elements.
+     */
+    private Map<String, RangerPolicy.RangerPolicyResource> createHdfsResource(URI uri) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+        String path = uri.getPath();
+        if (StringUtils.isNotBlank(path)) {
+            RangerPolicy.RangerPolicyResource pathResource = new RangerPolicy.RangerPolicyResource(path);
+            pathResource.setIsRecursive(true);
+            ret.put(HDFS_RESOURCE_PATH, pathResource);
+        }
+        return ret;
+    }
+
+    /**
+     * Create Ozone resource elements.
+     */
+    private Map<String, RangerPolicy.RangerPolicyResource> createOzoneResource(URI uri, String scheme) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+
+        if ("ofs".equals(scheme)) {
+            String path = uri.getPath();
+            if (StringUtils.isNotBlank(path)) {
+                String[] parts = path.split("/");
+                if (parts.length >= 2) {
+                    ret.put(OZONE_RESOURCE_VOLUME, new RangerPolicy.RangerPolicyResource(parts[1]));
+                    if (parts.length >= 3) {
+                        ret.put(OZONE_RESOURCE_BUCKET, new RangerPolicy.RangerPolicyResource(parts[2]));
+                        if (parts.length >= 4) {
+                            String key = String.join("/", java.util.Arrays.copyOfRange(parts, 3, parts.length));
+                            RangerPolicy.RangerPolicyResource keyResource = new RangerPolicy.RangerPolicyResource(key);
+                            keyResource.setIsRecursive(true);
+                            ret.put(OZONE_RESOURCE_KEY, keyResource);
+                        }
+                    }
+                }
+            }
+        } else {
+            String host = uri.getHost();
+            String path = uri.getPath();
+
+            if (StringUtils.isNotBlank(host)) {
+                String[] hostParts = host.split("\\.");
+                if (hostParts.length >= 2) {
+                    ret.put(OZONE_RESOURCE_BUCKET, new RangerPolicy.RangerPolicyResource(hostParts[0]));
+                    ret.put(OZONE_RESOURCE_VOLUME, new RangerPolicy.RangerPolicyResource(hostParts[1]));
+                }
+            }
+
+            if (StringUtils.isNotBlank(path) && !"/".equals(path)) {
+                String key = path.startsWith("/") ? path.substring(1) : path;
+                RangerPolicy.RangerPolicyResource keyResource = new RangerPolicy.RangerPolicyResource(key);
+                keyResource.setIsRecursive(true);
+                ret.put(OZONE_RESOURCE_KEY, keyResource);
+            }
+        }
+
+        return ret;
+    }
+
+    /**
+     * Create S3 resource elements.
+     */
+    private Map<String, RangerPolicy.RangerPolicyResource> createS3Resource(URI uri) {
+        Map<String, RangerPolicy.RangerPolicyResource> ret = new HashMap<>();
+
+        String bucket = uri.getHost();
+        String path = uri.getPath();
+
+        if (StringUtils.isNotBlank(bucket)) {
+            ret.put(S3_RESOURCE_BUCKET, new RangerPolicy.RangerPolicyResource(bucket));
+        }
+
+        if (StringUtils.isNotBlank(path) && !"/".equals(path)) {
+            String s3Path = path.startsWith("/") ? path.substring(1) : path;
+            RangerPolicy.RangerPolicyResource pathResource = new RangerPolicy.RangerPolicyResource(s3Path);
+            pathResource.setIsRecursive(true);
+            ret.put(S3_RESOURCE_PATH, pathResource);
+        }
+
+        return ret;
+    }
+
+    public boolean isHmsEnabled() {
+        return hmsEnabled;
+    }
+
+    public String getHiveServiceName() {
+        return hiveServiceName;
+    }
+
+    public String getHdfsServiceName() {
+        return hdfsServiceName;
+    }
+
+    public String getOzoneServiceName() {
+        return ozoneServiceName;
+    }
+
+    public String getS3ServiceName() {
+        return s3ServiceName;
+    }
+}

--- a/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
+++ b/security-admin/src/main/resources/META-INF/jpa_named_queries.xml
@@ -2048,6 +2048,48 @@
 
 	<!-- RMS queries -->
 
+	<named-query name="XXRMSResourceMapping.getResourceMapping">
+		<query>SELECT obj.hlResourceId, obj.llResourceId FROM XXRMSResourceMapping obj
+		</query>
+	</named-query>
+
+	<named-query name="XXRMSResourceMapping.getResourceMappingsSinceVersion">
+		<query>SELECT obj.hlResourceId, obj.llResourceId FROM XXRMSResourceMapping obj WHERE obj.mappingVersion &gt; :sinceVersion
+		</query>
+	</named-query>
+
+	<named-query name="XXRMSResourceMapping.findChangedMappingsForService">
+		<query>SELECT m.hlResourceId, m.llResourceId
+			FROM XXRMSResourceMapping m, XXRMSServiceResource ll
+			WHERE m.llResourceId = ll.id
+			  AND ll.serviceId = :serviceId
+			  AND m.mappingVersion &gt; :sinceVersion
+			  AND m.mappingVersion &lt;= :currentVersion
+		</query>
+	</named-query>
+
+	<named-query name="XXRMSServiceResource.findByIds">
+		<query>SELECT obj FROM XXRMSServiceResource obj WHERE obj.id IN :ids
+		</query>
+	</named-query>
+
+	<named-query name="XXRMSDeletionLog.findByServiceSinceVersion">
+		<query>SELECT obj FROM XXRMSDeletionLog obj
+			WHERE obj.llServiceId = :serviceId AND obj.version &gt; :sinceVersion
+			ORDER BY obj.version ASC, obj.id ASC
+		</query>
+	</named-query>
+
+	<named-query name="XXRMSDeletionLog.getMinVersion">
+		<query>SELECT MIN(obj.version) FROM XXRMSDeletionLog obj
+		</query>
+	</named-query>
+
+	<named-query name="XXRMSDeletionLog.deleteOlderThanVersion">
+		<query>DELETE FROM XXRMSDeletionLog obj WHERE obj.version &lt; :minRetainedVersion
+		</query>
+	</named-query>
+
 	<named-query name="XXRMSResourceMapping.deleteByHlResourceId">
 		<query>DELETE FROM XXRMSResourceMapping obj WHERE obj.hlResourceId = :resourceId
 		</query>
@@ -2151,6 +2193,37 @@
 
 	<named-query name="XXRMSMappingProvider.findByName">
 		<query>select obj from XXRMSMappingProvider obj where obj.name = :name</query>
+	</named-query>
+
+	<!--
+		Atomic, monotonic forward-only update of the deletion-tracking watermark.
+		Used by both the lazy-init path (after upgrade) and the prune path. By
+		updating only the watermark column with a guarded WHERE, we cannot lose
+		the concurrent last_known_version write performed by the RMS poller.
+	-->
+	<named-query name="XXRMSMappingProvider.advanceDeletionTrackingFromVersion">
+		<query>UPDATE XXRMSMappingProvider obj
+			SET obj.deletionTrackingFromVersion = :minVersion
+			WHERE obj.name = :name
+			  AND (obj.deletionTrackingFromVersion IS NULL
+			       OR obj.deletionTrackingFromVersion &lt; :minVersion)
+		</query>
+	</named-query>
+
+	<!--
+		Conditional initial-snapshot of the watermark: set it to :initVersion
+		only if no real value was ever persisted. We treat NULL and 0 as
+		"unset" (the latter is the schema default for upgraded installs that
+		already had x_rms_mapping_provider rows). A subsequent prune that
+		advances the watermark always wins because of the &lt; guard above.
+	-->
+	<named-query name="XXRMSMappingProvider.initDeletionTrackingFromVersion">
+		<query>UPDATE XXRMSMappingProvider obj
+			SET obj.deletionTrackingFromVersion = :initVersion
+			WHERE obj.name = :name
+			  AND (obj.deletionTrackingFromVersion IS NULL
+			       OR obj.deletionTrackingFromVersion = 0)
+		</query>
 	</named-query>
 
 	<named-query name="XXRole.findByUserId">

--- a/security-admin/src/main/resources/conf.dist/security-applicationContext.xml
+++ b/security-admin/src/main/resources/conf.dist/security-applicationContext.xml
@@ -44,6 +44,7 @@ http://www.springframework.org/schema/security/spring-security-oauth2-2.0.xsd">
 	<security:http pattern="/service/assets/resources/grant" security="none"/>
 	<security:http pattern="/service/assets/resources/revoke" security="none"/>
 	<security:http pattern="/service/gds/download/*" security="none"/>
+	<security:http pattern="/service/rms/mappings/download/*" security="none"/>
 	<security:http pattern="/service/plugins/policies/download/*" security="none"/>
 	<security:http pattern="/service/plugins/services/grant/*" security="none"/>
 	<security:http pattern="/service/plugins/services/revoke/*" security="none"/>


### PR DESCRIPTION
These two were already present:
- ODP-7180 Add RW Storage Type in Ranger Hive service def (#161)
- ODP-7094 Improve Ranger UserSync LDAP with SASL binding

And "ODP-6363 Initial Ranger mapper service sync support (#139)" had a conflict in `ranger-yunikorn-agent/src/main/java/io/acceldata/yunikorn/ranger/RangerHttpClient.java` as this never existed in this codebase.